### PR TITLE
Bugfix: Comparison failed when reverting to original value

### DIFF
--- a/lib/Reactify.re
+++ b/lib/Reactify.re
@@ -19,8 +19,8 @@ module Make = (ReconcilerImpl: Reconciler) => {
      a function of type unit => elementWithChildren ?
    */
   and component = {
-      element,
-      render: unit => elementWithChildren
+    element,
+    render: unit => elementWithChildren,
   }
   and childComponents = list(component)
   /*
@@ -96,9 +96,7 @@ module Make = (ReconcilerImpl: Reconciler) => {
 
   let empty: component = {
     element: Component,
-    render: () => {
-        (Component, [], [], __globalContext^)
-    },
+    render: () => (Component, [], [], __globalContext^),
   };
 
   let component = (~children: childComponents=[], c: componentFunction) => {
@@ -123,8 +121,8 @@ module Make = (ReconcilerImpl: Reconciler) => {
 
   let primitiveComponent = (~children, prim) => {
     let comp: component = {
-        element: Primitive(prim),
-        render: () => (Primitive(prim), children, [], __globalContext^)
+      element: Primitive(prim),
+      render: () => (Primitive(prim), children, [], __globalContext^),
     };
     comp;
   };
@@ -299,16 +297,16 @@ module Make = (ReconcilerImpl: Reconciler) => {
                 /* Check if the primitive type is the same - if it is, we can simply update the node */
                 /* If not, we'll replace the node */
                 if (Utility.areConstructorsEqual(oldPrim, newPrim)) {
-                    ReconcilerImpl.updateInstance(b, oldPrim, newPrim);
-                    i.component = newInstance.component;
-                    i.childInstances =
-                      reconcileChildren(
-                        b,
-                        i.childInstances,
-                        newInstance.children,
-                        context,
-                      );
-                    i;
+                  ReconcilerImpl.updateInstance(b, oldPrim, newPrim);
+                  i.component = newInstance.component;
+                  i.childInstances =
+                    reconcileChildren(
+                      b,
+                      i.childInstances,
+                      newInstance.children,
+                      context,
+                    );
+                  i;
                 } else {
                   ReconcilerImpl.replaceChild(rootNode, a, b);
                   newInstance;

--- a/lib/Reactify.re
+++ b/lib/Reactify.re
@@ -29,7 +29,7 @@ module Make = (ReconcilerImpl: Reconciler) => {
       effects that need to be run, and corresponding nodes.
    */
   and instance = {
-    component,
+    mutable component,
     children: childComponents,
     node: option(ReconcilerImpl.node),
     rootNode: ReconcilerImpl.node,
@@ -300,6 +300,7 @@ module Make = (ReconcilerImpl: Reconciler) => {
                 /* If not, we'll replace the node */
                 if (Utility.areConstructorsEqual(oldPrim, newPrim)) {
                     ReconcilerImpl.updateInstance(b, oldPrim, newPrim);
+                    i.component = newInstance.component;
                     i.childInstances =
                       reconcileChildren(
                         b,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reason-reactify",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Reason workflow with Esy",
   "license": "MIT",
   "esy": {

--- a/test/PrimitiveComponentTest.re
+++ b/test/PrimitiveComponentTest.re
@@ -85,7 +85,6 @@ test("ReplaceChildNodeTest", () => {
    print_endline ("going for the update....");
    TestReact.updateContainer(container, <aComponent testVal={1}><bComponent /></aComponent>);
 
-
     TestReconciler.show(rootNode);
     let expectedStructure = TreeNode(Root, [TreeNode(A(1), [TreeLeaf(B)])]);
    validateStructure(rootNode, expectedStructure);
@@ -128,7 +127,6 @@ test("ReplaceNodeTest", () => {
    validateStructure(rootNode, expectedStructure);
 });
 
-
 test("RenderingChildrenTest", () => {
   let rootNode = createRootNode();
   let container = TestReact.createContainer(rootNode);
@@ -141,5 +139,17 @@ test("RenderingChildrenTest", () => {
 
   TestReact.updateContainer(container, component());
 
+  validateStructure(rootNode, expectedStructure);
+});
+
+test("Regression Test - update, revert does not re-render node", () => {
+  let rootNode = createRootNode();
+  let container = TestReact.createContainer(rootNode);
+
+  TestReact.updateContainer(container, <aComponent testVal={0} />);
+  TestReact.updateContainer(container, <aComponent testVal={1} />);
+  TestReact.updateContainer(container, <aComponent testVal={0} />);
+
+  let expectedStructure = TreeNode(Root, [TreeLeaf(A(0))]);
   validateStructure(rootNode, expectedStructure);
 });

--- a/test/PrimitiveComponentTest.re
+++ b/test/PrimitiveComponentTest.re
@@ -14,10 +14,7 @@ let cComponent = (~children, ()) =>
   TestReact.primitiveComponent(C, ~children);
 
 let component = () =>
-  <aComponent testVal=1>
-    <bComponent />
-    <bComponent />
-  </aComponent>;
+  <aComponent testVal=1> <bComponent /> <bComponent /> </aComponent>;
 
 test("BasicRenderTest", () => {
   let rootNode = createRootNode();
@@ -41,90 +38,117 @@ test("BasicRenderTest - multiple updates", () => {
 });
 
 test("UpdateNodeTest", () => {
-    let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+  let rootNode = createRootNode();
+  let container = TestReact.createContainer(rootNode);
 
-    TestReact.updateContainer(container, <aComponent testVal={1}/>);
+  TestReact.updateContainer(container, <aComponent testVal=1 />);
 
-    let expectedStructure = TreeNode(Root, [TreeLeaf(A(1))]);
-    validateStructure(rootNode, expectedStructure);
+  let expectedStructure = TreeNode(Root, [TreeLeaf(A(1))]);
+  validateStructure(rootNode, expectedStructure);
 
-    /* Now, we'll update the tree */
-    TestReact.updateContainer(container, <aComponent testVal={2}/>);
+  /* Now, we'll update the tree */
+  TestReact.updateContainer(container, <aComponent testVal=2 />);
 
-    let expectedStructure = TreeNode(Root, [TreeLeaf(A(2))]);
-    validateStructure(rootNode, expectedStructure);
+  let expectedStructure = TreeNode(Root, [TreeLeaf(A(2))]);
+  validateStructure(rootNode, expectedStructure);
 });
 
 test("UpdateChildNodeTest", () => {
-    let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+  let rootNode = createRootNode();
+  let container = TestReact.createContainer(rootNode);
 
-    TestReact.updateContainer(container, <aComponent testVal={1}><aComponent testVal={2} /></aComponent>);
+  TestReact.updateContainer(
+    container,
+    <aComponent testVal=1> <aComponent testVal=2 /> </aComponent>,
+  );
 
-    let expectedStructure = TreeNode(Root, [TreeNode(A(1), [TreeLeaf(A(2))])]);
-    validateStructure(rootNode, expectedStructure);
+  let expectedStructure =
+    TreeNode(Root, [TreeNode(A(1), [TreeLeaf(A(2))])]);
+  validateStructure(rootNode, expectedStructure);
 
-    /* Now, we'll update the tree */
-    TestReact.updateContainer(container, <aComponent testVal={1}><aComponent testVal={3} /></aComponent>);
+  /* Now, we'll update the tree */
+  TestReact.updateContainer(
+    container,
+    <aComponent testVal=1> <aComponent testVal=3 /> </aComponent>,
+  );
 
-    let expectedStructure = TreeNode(Root, [TreeNode(A(1), [TreeLeaf(A(3))])]);
-    validateStructure(rootNode, expectedStructure);
+  let expectedStructure =
+    TreeNode(Root, [TreeNode(A(1), [TreeLeaf(A(3))])]);
+  validateStructure(rootNode, expectedStructure);
 });
 
 test("ReplaceChildNodeTest", () => {
-   let rootNode = createRootNode();
-   let container = TestReact.createContainer(rootNode);
+  let rootNode = createRootNode();
+  let container = TestReact.createContainer(rootNode);
 
-   TestReact.updateContainer(container, <aComponent testVal={1}><aComponent testVal={2} /></aComponent>);
+  TestReact.updateContainer(
+    container,
+    <aComponent testVal=1> <aComponent testVal=2 /> </aComponent>,
+  );
 
-    let expectedStructure = TreeNode(Root, [TreeNode(A(1), [TreeLeaf(A(2))])]);
-   validateStructure(rootNode, expectedStructure);
+  let expectedStructure =
+    TreeNode(Root, [TreeNode(A(1), [TreeLeaf(A(2))])]);
+  validateStructure(rootNode, expectedStructure);
 
-   /* Now, we'll update the tree */
-   print_endline ("going for the update....");
-   TestReact.updateContainer(container, <aComponent testVal={1}><bComponent /></aComponent>);
+  /* Now, we'll update the tree */
+  print_endline("going for the update....");
+  TestReact.updateContainer(
+    container,
+    <aComponent testVal=1> <bComponent /> </aComponent>,
+  );
 
-    TestReconciler.show(rootNode);
-    let expectedStructure = TreeNode(Root, [TreeNode(A(1), [TreeLeaf(B)])]);
-   validateStructure(rootNode, expectedStructure);
+  TestReconciler.show(rootNode);
+  let expectedStructure =
+    TreeNode(Root, [TreeNode(A(1), [TreeLeaf(B)])]);
+  validateStructure(rootNode, expectedStructure);
 });
 
 test("ReplaceChildrenWithLessChildrenTest", () => {
-   let rootNode = createRootNode();
-   let container = TestReact.createContainer(rootNode);
+  let rootNode = createRootNode();
+  let container = TestReact.createContainer(rootNode);
 
-   TestReact.updateContainer(container, <aComponent testVal={1}>
-            <bComponent/>
-            <bComponent/>
-            <bComponent/>
-        </aComponent>);
+  TestReact.updateContainer(
+    container,
+    <aComponent testVal=1>
+      <bComponent />
+      <bComponent />
+      <bComponent />
+    </aComponent>,
+  );
 
-    let expectedStructure = TreeNode(Root, [TreeNode(A(1), [TreeLeaf(B), TreeLeaf(B), TreeLeaf(B)])]);
-   validateStructure(rootNode, expectedStructure);
+  let expectedStructure =
+    TreeNode(
+      Root,
+      [TreeNode(A(1), [TreeLeaf(B), TreeLeaf(B), TreeLeaf(B)])],
+    );
+  validateStructure(rootNode, expectedStructure);
 
-   /* Now, we'll update the tree */
-   print_endline ("going for the update....");
-   TestReact.updateContainer(container, <aComponent testVal={1}><bComponent /></aComponent>);
+  /* Now, we'll update the tree */
+  print_endline("going for the update....");
+  TestReact.updateContainer(
+    container,
+    <aComponent testVal=1> <bComponent /> </aComponent>,
+  );
 
-    let expectedStructure = TreeNode(Root, [TreeNode(A(1), [TreeLeaf(B)])]);
-   validateStructure(rootNode, expectedStructure);
+  let expectedStructure =
+    TreeNode(Root, [TreeNode(A(1), [TreeLeaf(B)])]);
+  validateStructure(rootNode, expectedStructure);
 });
 
 test("ReplaceNodeTest", () => {
-   let rootNode = createRootNode();
-   let container = TestReact.createContainer(rootNode);
+  let rootNode = createRootNode();
+  let container = TestReact.createContainer(rootNode);
 
-   TestReact.updateContainer(container, <aComponent testVal={1}/>);
+  TestReact.updateContainer(container, <aComponent testVal=1 />);
 
-   let expectedStructure = TreeNode(Root, [TreeLeaf(A(1))]);
-   validateStructure(rootNode, expectedStructure);
+  let expectedStructure = TreeNode(Root, [TreeLeaf(A(1))]);
+  validateStructure(rootNode, expectedStructure);
 
-   /* Now, we'll update the tree */
-   TestReact.updateContainer(container, <bComponent/>);
+  /* Now, we'll update the tree */
+  TestReact.updateContainer(container, <bComponent />);
 
-   let expectedStructure = TreeNode(Root, [TreeLeaf(B)]);
-   validateStructure(rootNode, expectedStructure);
+  let expectedStructure = TreeNode(Root, [TreeLeaf(B)]);
+  validateStructure(rootNode, expectedStructure);
 });
 
 test("RenderingChildrenTest", () => {
@@ -132,10 +156,7 @@ test("RenderingChildrenTest", () => {
   let container = TestReact.createContainer(rootNode);
 
   let expectedStructure: tree(primitives) =
-    TreeNode(
-      Root,
-      [TreeNode(A(1), [TreeLeaf(B), TreeLeaf(B)])]
-    );
+    TreeNode(Root, [TreeNode(A(1), [TreeLeaf(B), TreeLeaf(B)])]);
 
   TestReact.updateContainer(container, component());
 
@@ -146,9 +167,9 @@ test("Regression Test - update, revert does not re-render node", () => {
   let rootNode = createRootNode();
   let container = TestReact.createContainer(rootNode);
 
-  TestReact.updateContainer(container, <aComponent testVal={0} />);
-  TestReact.updateContainer(container, <aComponent testVal={1} />);
-  TestReact.updateContainer(container, <aComponent testVal={0} />);
+  TestReact.updateContainer(container, <aComponent testVal=0 />);
+  TestReact.updateContainer(container, <aComponent testVal=1 />);
+  TestReact.updateContainer(container, <aComponent testVal=0 />);
 
   let expectedStructure = TreeNode(Root, [TreeLeaf(A(0))]);
   validateStructure(rootNode, expectedStructure);


### PR DESCRIPTION
__Issue:__ If a component renders a primitive, then changes a property of the primitive, and then reverts it back - that final reversion would fail to render / update the node (`updateInstance` would not be called in that last case).

__Defect:__ We were only holding on to the _original_ primitive for comparison - that means when we do the final reversion, it would compare with the original, see that the primitives are not the same, and not bother updating.

__Fix:__ For now, we can just update the `component`.

We should also look at the instantiation in `reconcile` - we really don't need to always instantiate... we should just be re-rendering in the case there is an existing instance.