### PR TITLE
API: Add events to listen for begin / end reconciliation

### DIFF
--- a/lib/Reactify.re
+++ b/lib/Reactify.re
@@ -339,6 +339,7 @@ module Make = (ReconcilerImpl: Reconciler) => {
                       i.childInstances,
                       newInstance.children,
                       context,
+                      container,
                     );
                   i;
                 } else {

--- a/lib/Reactify.re
+++ b/lib/Reactify.re
@@ -37,7 +37,16 @@ module Make = (ReconcilerImpl: Reconciler) => {
     mutable effectInstances: Effects.effectInstances,
     state: State.HeterogenousMutableList.t,
     context: Context.HeterogenousHashtbl.t,
+    container: t,
   }
+  and container = {
+    onBeginReconcile: Event.t(ReconcilerImpl.node),
+    onEndReconcile: Event.t(ReconcilerImpl.node),
+
+    rootInstance: ref(option(instance)),
+    containerNode: ReconcilerImpl.node,
+  }
+  and t = container
   and childInstances = list(instance)
   /*
      An effectInstance is an effect that was already instantiated -
@@ -81,15 +90,37 @@ module Make = (ReconcilerImpl: Reconciler) => {
   /*
      Container API
    */
-  type container = {
-    rootInstance: ref(option(instance)),
-    rootNode: ReconcilerImpl.node,
-  };
-  type t = container;
+  type reconcileNotification = node => unit;
 
-  let createContainer = (rootNode: ReconcilerImpl.node) => {
-    let ret: container = {rootNode, rootInstance: ref(None)};
+  let createContainer = (~onBeginReconcile:option(reconcileNotification)=?, ~onEndReconcile:option(reconcileNotification)=?, rootNode: ReconcilerImpl.node) => {
+
+    let be = Event.create();
+    let ee = Event.create();
+
+    switch (onBeginReconcile) {
+    | Some(x) => 
+        let _ = Event.subscribe(be, x);
+        ();
+    | _ => ()
+    };
+
+    switch (onEndReconcile) {
+    | Some(x) => 
+        let _ = Event.subscribe(ee, x);
+        ();
+    | _ => ()
+    };
+
+    let ret: container = {
+        onBeginReconcile: be,
+        onEndReconcile: ee,
+        containerNode: rootNode, 
+        rootInstance: ref(None)
+    };
+
+
     ret;
+
   };
 
   type componentFunction = unit => component;
@@ -208,6 +239,7 @@ module Make = (ReconcilerImpl: Reconciler) => {
             previousInstance: option(instance),
             component: component,
             context: Context.t,
+            container: t,
           ) => {
     /* Recycle any previous effect instances */
     let previousEffectInstances = _getEffectsFromInstance(previousInstance);
@@ -254,6 +286,7 @@ module Make = (ReconcilerImpl: Reconciler) => {
         previousChildInstances,
         children,
         newContext,
+        container,
       );
 
     let instance: instance = {
@@ -265,6 +298,7 @@ module Make = (ReconcilerImpl: Reconciler) => {
       effectInstances,
       state: newState,
       context: newContext,
+      container: container,
     };
 
     /*
@@ -276,8 +310,8 @@ module Make = (ReconcilerImpl: Reconciler) => {
 
     instance;
   }
-  and reconcile = (rootNode, instance, component, context) => {
-    let newInstance = instantiate(rootNode, instance, component, context);
+  and reconcile = (rootNode, instance, component, context, container) => {
+    let newInstance = instantiate(rootNode, instance, component, context, container);
 
     let r =
       switch (instance) {
@@ -306,6 +340,7 @@ module Make = (ReconcilerImpl: Reconciler) => {
                         i.childInstances,
                         newInstance.children,
                         context,
+                        container
                       );
                     i;
                 } else {
@@ -320,6 +355,7 @@ module Make = (ReconcilerImpl: Reconciler) => {
                     i.childInstances,
                     newInstance.children,
                     context,
+                    container,
                   );
                 i;
               }
@@ -355,6 +391,7 @@ module Make = (ReconcilerImpl: Reconciler) => {
         currentChildInstances: childInstances,
         newChildren: list(component),
         context: Context.t,
+        container: t,
       ) => {
     let currentChildInstances: array(instance) =
       Array.of_list(currentChildInstances);
@@ -368,7 +405,7 @@ module Make = (ReconcilerImpl: Reconciler) => {
           None : Some(currentChildInstances[i]);
       let childComponent = newChildren[i];
       let newChildInstance =
-        reconcile(root, childInstance, childComponent, context);
+        reconcile(root, childInstance, childComponent, context, container);
       newChildInstances :=
         List.append(newChildInstances^, [newChildInstance]);
     };
@@ -401,7 +438,9 @@ module Make = (ReconcilerImpl: Reconciler) => {
       switch (context^) {
       | Some(i) =>
         let {rootNode, component, _} = i;
-        let _ = reconcile(rootNode, Some(i), component, i.context);
+        Event.dispatch(i.container.onBeginReconcile, rootNode);
+        let _ = reconcile(rootNode, Some(i), component, i.context, i.container);
+        Event.dispatch(i.container.onEndReconcile, rootNode);
         ();
       | _ => print_endline("WARNING: Skipping reconcile!")
       };
@@ -411,11 +450,13 @@ module Make = (ReconcilerImpl: Reconciler) => {
   };
 
   let updateContainer = (container, component) => {
-    let {rootNode, rootInstance} = container;
+    let {containerNode, rootInstance, onBeginReconcile, onEndReconcile} = container;
     let prevInstance = rootInstance^;
+    Event.dispatch(onBeginReconcile, containerNode);
     let nextInstance =
-      reconcile(rootNode, prevInstance, component, noContext);
+      reconcile(containerNode, prevInstance, component, noContext, container);
     rootInstance := Some(nextInstance);
+    Event.dispatch(onEndReconcile, containerNode);
   };
 };
 

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -60,7 +60,8 @@ module type React = {
   /*
        Container API
    */
-  let createContainer: node => t;
+  type reconcileNotification = node => unit;
+  let createContainer: (~onBeginReconcile:reconcileNotification=?, ~onEndReconcile:reconcileNotification=?, node) => t;
   let updateContainer: (t, component) => unit;
 
   /*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reason-reactify",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Reason workflow with Esy",
   "license": "MIT",
   "esy": {

--- a/test/ContainerTest.re
+++ b/test/ContainerTest.re
@@ -1,0 +1,83 @@
+/** Simple test cases */
+open TestReconciler;
+open TestUtility;
+
+module Event = Reactify.Event;
+
+/* Use our Reconciler to create our own instance */
+module TestReact = Reactify.Make(TestReconciler);
+let createRootNode = () => {children: ref([]), nodeId: 0, nodeType: Root};
+
+let aComponent = (~testVal, ~children, ()) =>
+  TestReact.primitiveComponent(A(testVal), ~children);
+let bComponent = (~children, ()) =>
+  TestReact.primitiveComponent(B, ~children);
+let cComponent = (~children, ()) =>
+  TestReact.primitiveComponent(C, ~children);
+
+test("beginReconcile / endReconcile are called for updateContainer", () => {
+  let rootNode = createRootNode();
+
+  let beginCount = ref(0);
+  let endCount = ref(0);
+
+  let onBeginReconcile = (_node) => {
+    beginCount := beginCount^ + 1;
+  };
+
+  let onEndReconcile = (_node) => {
+      endCount := endCount^ + 1;
+  }
+
+  let container = TestReact.createContainer(~onBeginReconcile, ~onEndReconcile, rootNode);
+
+  TestReact.updateContainer(container, <bComponent />);
+
+  assert(beginCount^ == 1);
+  assert(endCount^ == 1);
+});
+
+let componentThatUpdatesState = (~children, ~event: Event.t(int), ()) =>
+  TestReact.component(
+    () => {
+      let (s, setS) = TestReact.useState(2);
+
+      print_endline("Value: " ++ string_of_int(s));
+      TestReact.useEffect(() => {
+        let unsubscribe = Event.subscribe(event, v => setS(v));
+        () => unsubscribe();
+      });
+
+      <aComponent testVal=s />;
+    },
+    ~children,
+  );
+
+
+test("beginReconcile / endReconcile are called when updating state", () => {
+  let rootNode = createRootNode();
+
+  let beginCount = ref(0);
+  let endCount = ref(0);
+
+  let onBeginReconcile = (_node) => {
+    beginCount := beginCount^ + 1;
+  };
+
+  let onEndReconcile = (_node) => {
+    endCount := endCount^ + 1;
+  }
+
+  let container = TestReact.createContainer(~onBeginReconcile, ~onEndReconcile, rootNode);
+
+  let event: Event.t(int) = Event.create();
+  TestReact.updateContainer(container, <componentThatUpdatesState event />);
+
+  beginCount := 0;
+  endCount := 0;
+  Event.dispatch(event, 5);
+
+  assert(beginCount^ == 1);
+  assert(endCount^ == 1);
+});
+

--- a/test/Test.re
+++ b/test/Test.re
@@ -1,6 +1,7 @@
 /* TODO: Is there a better way for tests to be picked up automatically? */
 /* We could potentially create a lib/bin pair, and use `library_flags -linkall` */
 
+module ContainerTest = ContainerTest;
 module StateTest = StateTest;
 module PrimitiveComponentTest = PrimitiveComponentTest;
 module StatelessComponentTest = StatelessComponentTest;


### PR DESCRIPTION
It's helpful to know and be able to react when an internal component changes state / triggers a re-render. For a project like `revery`, that means we need to redraw the UI - having these events can help us catch those and know when we need to redraw.