### PR TITLE
Bugfix: State leaks between components

### DIFF
--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -32,7 +32,9 @@ module type React = {
 
   type element =
     | Primitive(primitives)
-    | Component
+    | Component(componentFunction)
+    | Provider
+    | Empty
   and renderedElement =
     | RenderedPrimitive(node)
   and elementWithChildren = (element, childComponents, list(effect), Context.t)
@@ -46,14 +48,13 @@ module type React = {
       element,
       render: unit => elementWithChildren
   }
+  and componentFunction = unit => component
   and childComponents = list(component)
   and effectInstance = unit => unit
   and effectInstances = list(effectInstance)
   /* An effect is a function sent to useEffect. We haven't run it yet, */
   /* But we will once the element is mounted */
   and effect = unit => effectInstance;
-
-  type componentFunction = unit => component;
 
   type t;
 

--- a/test/HooksUseStateTest.re
+++ b/test/HooksUseStateTest.re
@@ -26,6 +26,7 @@ let componentWithState = (~children, ()) =>
     },
     ~children,
   );
+
 type renderOption =
   /* | Nothing */
   | ComponentWithState
@@ -73,6 +74,30 @@ test("useState", () => {
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(5))]);
+    validateStructure(rootNode, expectedStructure);
+  });
+
+  test("useState doesn't leak state between components", () => {
+    let rootNode = createRootNode();
+
+    let container = TestReact.createContainer(rootNode);
+
+    let event: Event.t(int) = Event.create();
+
+    TestReact.updateContainer(container, <componentThatUpdatesState event />);
+
+    Event.dispatch(event, 5);
+
+    let expectedStructure: tree(primitives) =
+      TreeNode(Root, [TreeLeaf(A(5))]);
+    validateStructure(rootNode, expectedStructure);
+
+    TestReact.updateContainer(container, <componentWithState />);
+
+    /* The 'componentWithState' should have its own state, so it should revert back to 2 - */
+    /* and not pick up the state from the previous component */
+    let expectedStructure: tree(primitives) =
+      TreeNode(Root, [TreeLeaf(A(2))]);
     validateStructure(rootNode, expectedStructure);
   });
 

--- a/test/UtilityTest.re
+++ b/test/UtilityTest.re
@@ -45,4 +45,17 @@ test("Utility", () => {
     () =>
     assert(Utility.areConstructorsEqual(d11, d2) == true)
   );
+
+  test("Function equality", () => {
+    let a = () => ();
+    /* let b = () => (); */
+
+    let fn = (f) => f;
+
+    let a0 = fn(a);
+    let a1 = fn(a);
+
+
+    expect(a0 === a1).toBe(true);
+  });
 });


### PR DESCRIPTION
__Issue:__ If a component 'a' setsState, and then a component 'b' is rendered at the same level in the hierarchy, the component 'b' will pick up the previous components state.

This is bad for functionality, but also because we make an assumption that the types are the same via `Obj.magic` - so it is very problematic.

__Fix:__ Differentiate between components to decide if we should 'reuse' the existing state or start with a new state.