### PR TITLE
API: First-class modules for components

### DIFF
--- a/examples/Lambda_term.re
+++ b/examples/Lambda_term.re
@@ -118,30 +118,27 @@ let button = (~children, ~text, ~onClick, ()) => {
 
     This shows how you can use state with a callback from a primitive.
  */
-let incrementingButton = (~children, ()) =>
-  component(
-    () => {
-      let (count, setCount) = useState(0);
 
+module IncrementingButton = (val component((render, ~children, ()) => {
+    render(() => {
+
+      let (count, setCount) = useState(0);
       let update = () => setCount(count + 1);
 
       let text = count > 0 ? "Pressed!" : "Click me";
 
       <button text onClick=update />;
-    },
-    ~uniqueId="incrementingButton",
-    ~children,
-  );
-
+    }, ~children);
+}));
 /*
     Clock
 
     Custom clock component to show the time. Demonstrates
     use of `useEffect` and `setState` together.
  */
-let clock = (~children, ()) =>
-  component(
-    () => {
+module Clock = (val component((render, ~children, ()) => {
+    render(() => {
+
       let (time, setTime) = useState(0.);
       useEffect(() => {
         let evt = Lwt_engine.on_timer(1.0, true, _ => setTime(Unix.time()));
@@ -150,10 +147,9 @@ let clock = (~children, ()) =>
       });
 
       <label text={"Time: " ++ string_of_float(time)} />;
-    },
-    ~uniqueId="clock",
-    ~children,
-  );
+
+    }, ~children);
+}));
 
 let main = () => {
   let (waiter, wakener) = wait();
@@ -169,8 +165,8 @@ let main = () => {
   let render = () =>
     <vbox>
       <label text="Hello from Reactify!" />
-      <clock />
-      <incrementingButton />
+      <Clock />
+      <IncrementingButton />
       <button onClick=quit text="Quit" />
     </vbox>;
 

--- a/examples/Lambda_term.re
+++ b/examples/Lambda_term.re
@@ -67,7 +67,8 @@ module Reconciler = {
     | Container(z) => (z :> widget)
     };
 
-  let updateInstance = (node: node, _oldPrimitive: primitives, newPrimitive: primitives) =>
+  let updateInstance =
+      (node: node, _oldPrimitive: primitives, newPrimitive: primitives) =>
     switch (newPrimitive, node) {
     | (Label(txt), Label(n)) => n#set_text(txt)
     | (Button(buttonProps), Button(n)) =>
@@ -119,37 +120,45 @@ let button = (~children, ~text, ~onClick, ()) => {
     This shows how you can use state with a callback from a primitive.
  */
 
-module IncrementingButton = (val component((render, ~children, ()) => {
-    render(() => {
+module IncrementingButton = (
+  val component((render, ~children, ()) =>
+        render(
+          () => {
+            let (count, setCount) = useState(0);
+            let update = () => setCount(count + 1);
 
-      let (count, setCount) = useState(0);
-      let update = () => setCount(count + 1);
+            let text = count > 0 ? "Pressed!" : "Click me";
 
-      let text = count > 0 ? "Pressed!" : "Click me";
-
-      <button text onClick=update />;
-    }, ~children);
-}));
+            <button text onClick=update />;
+          },
+          ~children,
+        )
+      )
+);
 /*
     Clock
 
     Custom clock component to show the time. Demonstrates
     use of `useEffect` and `setState` together.
  */
-module Clock = (val component((render, ~children, ()) => {
-    render(() => {
+module Clock = (
+  val component((render, ~children, ()) =>
+        render(
+          () => {
+            let (time, setTime) = useState(0.);
+            useEffect(() => {
+              let evt =
+                Lwt_engine.on_timer(1.0, true, _ => setTime(Unix.time()));
 
-      let (time, setTime) = useState(0.);
-      useEffect(() => {
-        let evt = Lwt_engine.on_timer(1.0, true, _ => setTime(Unix.time()));
+              () => Lwt_engine.stop_event(evt);
+            });
 
-        () => Lwt_engine.stop_event(evt);
-      });
-
-      <label text={"Time: " ++ string_of_float(time)} />;
-
-    }, ~children);
-}));
+            <label text={"Time: " ++ string_of_float(time)} />;
+          },
+          ~children,
+        )
+      )
+);
 
 let main = () => {
   let (waiter, wakener) = wait();

--- a/lib/ComponentId.re
+++ b/lib/ComponentId.re
@@ -1,0 +1,31 @@
+type t = {
+    id: int,
+    friendlyName: string,
+};
+
+type scope = {
+    mutable lastId: int
+}
+
+let createScope = () => {
+    let ret: scope = {
+        lastId: 0,
+    };
+    ret;
+}
+
+let newId = (~friendlyName:option(string)=?, scope: scope) => {
+    let id = scope.lastId + 1;
+    scope.lastId = id;
+
+    let friendlyName = switch(friendlyName) {
+    | Some(x) => x   
+    | None => "component" ++ string_of_int(id);
+    };
+
+    let ret: t = {
+        id,
+        friendlyName,
+    };
+    ret;
+};

--- a/lib/ComponentId.re
+++ b/lib/ComponentId.re
@@ -1,31 +1,25 @@
 type t = {
-    id: int,
-    friendlyName: string,
+  id: int,
+  friendlyName: string,
 };
 
-type scope = {
-    mutable lastId: int
-}
+type scope = {mutable lastId: int};
 
 let createScope = () => {
-    let ret: scope = {
-        lastId: 0,
-    };
-    ret;
-}
+  let ret: scope = {lastId: 0};
+  ret;
+};
 
-let newId = (~friendlyName:option(string)=?, scope: scope) => {
-    let id = scope.lastId + 1;
-    scope.lastId = id;
+let newId = (~friendlyName: option(string)=?, scope: scope) => {
+  let id = scope.lastId + 1;
+  scope.lastId = id;
 
-    let friendlyName = switch(friendlyName) {
-    | Some(x) => x   
-    | None => "component" ++ string_of_int(id);
+  let friendlyName =
+    switch (friendlyName) {
+    | Some(x) => x
+    | None => "component" ++ string_of_int(id)
     };
 
-    let ret: t = {
-        id,
-        friendlyName,
-    };
-    ret;
+  let ret: t = {id, friendlyName};
+  ret;
 };

--- a/lib/Context.re
+++ b/lib/Context.re
@@ -1,27 +1,20 @@
 /*
- Context
-*/
+  Context
+ */
 
-module HeterogenousHashtbl {
-    type t = Hashtbl.t(int, Object.t);
+module HeterogenousHashtbl = {
+  type t = Hashtbl.t(int, Object.t);
 
-    let create = () => Hashtbl.create(16)
+  let create = () => Hashtbl.create(16);
 };
 
 type t = HeterogenousHashtbl.t;
 
-let create = () => {
-    HeterogenousHashtbl.create();
-};
+let create = () => HeterogenousHashtbl.create();
 
-let clone = (original: t) => {
-    Hashtbl.copy(original);
-}
+let clone = (original: t) => Hashtbl.copy(original);
 
-let set = (context: t, key: int, obj: Object.t) => {
-    Hashtbl.replace(context, key, obj);
-};
+let set = (context: t, key: int, obj: Object.t) =>
+  Hashtbl.replace(context, key, obj);
 
-let get = (context: t, key: int) => {
-    Hashtbl.find_opt(context, key);
-}
+let get = (context: t, key: int) => Hashtbl.find_opt(context, key);

--- a/lib/Effects.re
+++ b/lib/Effects.re
@@ -4,16 +4,28 @@
   Module encapsulating some simple effect manipulation
 */
 
-type effectInstance = unit => unit
+type effectCondition = option(Object.t)
+and effectInstanceFunction = unit => unit
+and effectFunction = unit => effectInstanceFunction
+and effectInstance = {
+    fn: effectInstanceFunction,
+    condition: effectCondition
+}
 and effectInstances = list(effectInstance)
 /* An effect is a function sent to useEffect. We haven't run it yet, */
 /* But we will once the element is mounted */
-and effect = unit => effectInstance;
+and effect = {
+    effectFn: unit => effectInstanceFunction,
+    effectCondition: effectCondition,
+}
+and effects = list(effect);
+
+let noop = () => ();
 
 /*
   Core type for the effects module
 */
-type t = ref(list(effect));
+type t = ref(effects);
 
 let create: unit => t = () => {
     ref([]);
@@ -23,7 +35,17 @@ let resetEffects: t => unit = (effects: t) => {
     effects := [];
 };
 
-let addEffect: (t, effect) => unit = (effects, effect) => {
+let addEffect = (~condition:'a=?, effects: ref(effects), effectFunction: effectFunction) => {
+    let boxedCondition = switch(condition) {
+    | None => None
+    | Some(x) => Some(Object.to_object(x))
+    };
+
+    let effect: effect = {
+      effectFn: effectFunction,
+      effectCondition: boxedCondition,
+    };
+
     effects := List.append(effects^, [effect]);
 };
 
@@ -31,10 +53,31 @@ let getEffects: (t) => list(effect) = (effects) => {
     effects^;
 };
 
-let runEffects: (list(effect)) => effectInstances = (effects) => {
-    List.map(e => e(), effects);
+let rec createEmptyEffectInstances = (x: int) => {
+    switch (x > 0) {
+    | true => [{ fn: noop, condition: None}, ...createEmptyEffectInstances(x - 1)]
+    | false => []
+    };
 };
 
-let runEffectInstances: (effectInstances) => unit = (effectInstances) => {
-    List.iter(ei => ei(), effectInstances);
+let runEffects: (effectInstances, effects) => effectInstances = (previousInstances, effects) => {
+
+    let fn = (acc: effectInstances, previousEffectInstance: effectInstance, currentEffect: effect) => {
+        previousEffectInstance.fn(); 
+        let effectInstanceFn = currentEffect.effectFn();
+        let effectInstance: effectInstance = {
+            condition: currentEffect.effectCondition,
+            fn: effectInstanceFn,
+        };
+        [effectInstance, ...acc]
+    };
+
+    let initial: effectInstances = [];
+
+    List.fold_left2(fn, initial, previousInstances, effects);
+    /* List.rev(l); */
 };
+
+/* let runEffectInstances: (effectInstances) => unit = (effectInstances) => { */
+/*     List.iter(ei => ei(), effectInstances); */
+/* }; */

--- a/lib/Effects.re
+++ b/lib/Effects.re
@@ -63,13 +63,19 @@ let rec createEmptyEffectInstances = (x: int) => {
 let runEffects: (effectInstances, effects) => effectInstances = (previousInstances, effects) => {
 
     let fn = (acc: effectInstances, previousEffectInstance: effectInstance, currentEffect: effect) => {
-        previousEffectInstance.fn(); 
-        let effectInstanceFn = currentEffect.effectFn();
-        let effectInstance: effectInstance = {
-            condition: currentEffect.effectCondition,
-            fn: effectInstanceFn,
+        let newInstance = switch (previousEffectInstance.condition == currentEffect.effectCondition && previousEffectInstance.condition !== None) {
+        | true => previousEffectInstance
+        | false =>
+            previousEffectInstance.fn(); 
+            let effectInstanceFn = currentEffect.effectFn();
+            let ret: effectInstance = {
+                condition: currentEffect.effectCondition,
+                fn: effectInstanceFn,
+            };
+            ret;
         };
-        [effectInstance, ...acc]
+
+        [newInstance, ...acc]
     };
 
     let initial: effectInstances = [];

--- a/lib/Effects.re
+++ b/lib/Effects.re
@@ -60,7 +60,12 @@ let rec createEmptyEffectInstances = (x: int) => {
     };
 };
 
-let runEffects: (effectInstances, effects) => effectInstances = (previousInstances, effects) => {
+let runEffects: (~previousInstances:effectInstances=?, effects) => effectInstances = (~previousInstances:option(effectInstances)=?, effects) => {
+
+    let previousInstances = switch (previousInstances) {
+    | None => createEmptyEffectInstances(List.length(effects))
+    | Some(x) => x
+    };
 
     let fn = (acc: effectInstances, previousEffectInstance: effectInstance, currentEffect: effect) => {
         let newInstance = switch (previousEffectInstance.condition == currentEffect.effectCondition && previousEffectInstance.condition !== None) {
@@ -82,6 +87,11 @@ let runEffects: (effectInstances, effects) => effectInstances = (previousInstanc
 
     List.fold_left2(fn, initial, previousInstances, effects);
     /* List.rev(l); */
+};
+
+let drainEffects: (effectInstances) => unit = (effects: effectInstances) => {
+    let fn = (ei) => ei.fn();
+    List.iter(fn, effects);
 };
 
 /* let runEffectInstances: (effectInstances) => unit = (effectInstances) => { */

--- a/lib/Effects.re
+++ b/lib/Effects.re
@@ -1,96 +1,100 @@
 /*
-  Effects.re
+   Effects.re
 
-  Module encapsulating some simple effect manipulation
-*/
+   Module encapsulating some simple effect manipulation
+ */
 
-type effectCondition = 
-| Always 
-| MountUnmount
+type effectCondition =
+  | Always
+  | MountUnmount
 and effectInstanceFunction = unit => unit
 and effectFunction = unit => effectInstanceFunction
 and effectInstance = {
-    fn: effectInstanceFunction,
-    condition: effectCondition
+  fn: effectInstanceFunction,
+  condition: effectCondition,
 }
 and effectInstances = list(effectInstance)
 /* An effect is a function sent to useEffect. We haven't run it yet, */
 /* But we will once the element is mounted */
 and effect = {
-    effectFn: unit => effectInstanceFunction,
-    effectCondition: effectCondition,
+  effectFn: unit => effectInstanceFunction,
+  effectCondition,
 }
 and effects = list(effect);
 
 let noop = () => ();
 
 /*
-  Core type for the effects module
-*/
+   Core type for the effects module
+ */
 type t = ref(effects);
 
-let create: unit => t = () => {
-    ref([]);
+let create: unit => t = () => ref([]);
+
+let resetEffects: t => unit = (effects: t) => effects := [];
+
+let addEffect =
+    (
+      ~condition: effectCondition,
+      effects: ref(effects),
+      effectFunction: effectFunction,
+    ) => {
+  let effect: effect = {effectFn: effectFunction, effectCondition: condition};
+
+  effects := List.append(effects^, [effect]);
 };
 
-let resetEffects: t => unit = (effects: t) => {
-    effects := [];
-};
+let getEffects: t => list(effect) = effects => effects^;
 
-let addEffect = (~condition:effectCondition, effects: ref(effects), effectFunction: effectFunction) => {
-    let effect: effect = {
-      effectFn: effectFunction,
-      effectCondition: condition,
-    };
+let rec createEmptyEffectInstances = (x: int) =>
+  x > 0 ?
+    [{fn: noop, condition: Always}, ...createEmptyEffectInstances(x - 1)] :
+    [];
 
-    effects := List.append(effects^, [effect]);
-};
+let runEffects:
+  (~previousInstances: effectInstances=?, effects) => effectInstances =
+  (~previousInstances: option(effectInstances)=?, effects) => {
+    let previousInstances =
+      switch (previousInstances) {
+      | None => createEmptyEffectInstances(List.length(effects))
+      | Some(x) => x
+      };
 
-let getEffects: (t) => list(effect) = (effects) => {
-    effects^;
-};
-
-let rec createEmptyEffectInstances = (x: int) => {
-    switch (x > 0) {
-    | true => [{ fn: noop, condition: Always}, ...createEmptyEffectInstances(x - 1)]
-    | false => []
-    };
-};
-
-let runEffects: (~previousInstances:effectInstances=?, effects) => effectInstances = (~previousInstances:option(effectInstances)=?, effects) => {
-    let previousInstances = switch (previousInstances) {
-    | None => createEmptyEffectInstances(List.length(effects))
-    | Some(x) => x
-    };
-
-    let fn = (acc: effectInstances, previousEffectInstance: effectInstance, currentEffect: effect) => {
-        let pc = previousEffectInstance.condition;
-        let nc = currentEffect.effectCondition;
-        let newInstance = switch (pc === nc && pc === MountUnmount) {
-        | true => previousEffectInstance
-        | false =>
-            previousEffectInstance.fn(); 
+    let fn =
+        (
+          acc: effectInstances,
+          previousEffectInstance: effectInstance,
+          currentEffect: effect,
+        ) => {
+      let pc = previousEffectInstance.condition;
+      let nc = currentEffect.effectCondition;
+      let newInstance =
+        pc === nc && pc === MountUnmount ?
+          previousEffectInstance :
+          {
+            previousEffectInstance.fn();
             let effectInstanceFn = currentEffect.effectFn();
             let ret: effectInstance = {
-                condition: currentEffect.effectCondition,
-                fn: effectInstanceFn,
+              condition: currentEffect.effectCondition,
+              fn: effectInstanceFn,
             };
             ret;
-        };
+          };
 
-        [newInstance, ...acc]
+      [newInstance, ...acc];
     };
 
     let initial: effectInstances = [];
 
     let l = List.fold_left2(fn, initial, previousInstances, effects);
     List.rev(l);
-};
+  };
 
-let drainEffects: (effectInstances) => unit = (effects: effectInstances) => {
-    let fn = (ei) => ei.fn();
+let drainEffects: effectInstances => unit =
+  (effects: effectInstances) => {
+    let fn = ei => ei.fn();
     List.iter(fn, effects);
-};
+  };
 
 /* let runEffectInstances: (effectInstances) => unit = (effectInstances) => { */
 /*     List.iter(ei => ei(), effectInstances); */

--- a/lib/Event.re
+++ b/lib/Event.re
@@ -7,12 +7,12 @@ type t('a) = ref(list(cb('a)));
 let create = () => ref([]);
 
 let subscribe = (evt: t('a), f: cb('a)) => {
-    evt := List.append(evt^, [f]);
-    let unsubscribe = () => {
-        print_endline ("unsubscribe");
-        evt := List.filter((f) => f !== f, evt^)
-    };
-    unsubscribe;
-}
+  evt := List.append(evt^, [f]);
+  let unsubscribe = () => {
+    print_endline("unsubscribe");
+    evt := List.filter(f => f !== f, evt^);
+  };
+  unsubscribe;
+};
 
 let dispatch = (evt: t('a), v: 'a) => List.iter(c => c(v), evt^);

--- a/lib/Object.re
+++ b/lib/Object.re
@@ -1,14 +1,14 @@
 /*
 
- This module is _not ideal_ - we should be leveraging the magic of the OCaml type system -
- not `Obj.magic` - to help us here. We use this to assist in creating a heterogenous list of state,
- since `useState` can be called with any type, and we're preserving the semantics
- of the React hooks model.
+  This module is _not ideal_ - we should be leveraging the magic of the OCaml type system -
+  not `Obj.magic` - to help us here. We use this to assist in creating a heterogenous list of state,
+  since `useState` can be called with any type, and we're preserving the semantics
+  of the React hooks model.
 
- There are other potential options - but they would require API changes.
+  There are other potential options - but they would require API changes.
 
- Definitely open to alternatives!
-*/
+  Definitely open to alternatives!
+ */
 
 type t;
 

--- a/lib/Reactify.re
+++ b/lib/Reactify.re
@@ -260,6 +260,15 @@ module Make = (ReconcilerImpl: Reconciler) => {
     __globalState := noState;
     let newState = ComponentState.getNewState(state);
 
+    let oldEffectCount = List.length(previousEffectInstances);
+    let newEffectCount = List.length(effects);
+    /* Assume that, if there were no previous effects, this must be a first-time render */
+    /* In that case, we'll create an empty set of effects to match the new effects */
+    let previousEffectInstances = switch(oldEffectCount == 0 && newEffectCount > 0) {
+    | true => Effects.createEmptyEffectInstances(newEffectCount)
+    | false => previousEffectInstances
+    };
+
     /* TODO: Should this be deferred until we actually mount the component? */
     let effectInstances = Effects.runEffects(previousEffectInstances, effects);
 

--- a/lib/Reactify.re
+++ b/lib/Reactify.re
@@ -144,11 +144,12 @@ module Make = (ReconcilerImpl: Reconciler) => {
 
   module type COMPONENT = {
     type t;
+    /* let derp: unit => unit; */
     let createElement: t;
   };
 
   let component2 = (type a, fn): (module COMPONENT with type t = a) => {
-    (module {
+    (module {        
         type t = a;
         let createElement = fn;
     }) 

--- a/lib/Reactify.re
+++ b/lib/Reactify.re
@@ -128,26 +128,25 @@ module Make = (ReconcilerImpl: Reconciler) => {
 
   type renderFunction =
     (~children: list(component)=?, componentFunction) => component;
-  let render =
-    (id: ComponentId.t, ~children: option(list(component))=?, c) => {
-      ignore(children);
-      let ret: component = {
-        element: Component(id),
-        render: () => {
-          Effects.resetEffects(__globalEffects);
-          let children: list(component) = [c()];
-          let effects = Effects.getEffects(__globalEffects);
-          let renderResult: elementWithChildren = (
-            Component(id),
-            children,
-            effects,
-            __globalContext^,
-          );
-          renderResult;
-        },
-      };
-      ret;
+  let render = (id: ComponentId.t, ~children: option(list(component))=?, c) => {
+    ignore(children);
+    let ret: component = {
+      element: Component(id),
+      render: () => {
+        Effects.resetEffects(__globalEffects);
+        let children: list(component) = [c()];
+        let effects = Effects.getEffects(__globalEffects);
+        let renderResult: elementWithChildren = (
+          Component(id),
+          children,
+          effects,
+          __globalContext^,
+        );
+        renderResult;
+      },
     };
+    ret;
+  };
 
   module type Component = {
     type t;

--- a/lib/Reactify.re
+++ b/lib/Reactify.re
@@ -142,16 +142,37 @@ module Make = (ReconcilerImpl: Reconciler) => {
     ret;
   };
 
+  type renderFunction = (~children:list(component)=?, componentFunction) => component;
+  let render2: renderFunction = (~children:option(list(component))=?, c) => {
+    ignore(children);
+    let ret: component = {
+      element: Component("1"),
+      render: () => {
+        Effects.resetEffects(__globalEffects);
+        let children: list(component) = [c()];
+        let effects = Effects.getEffects(__globalEffects);
+        let renderResult: elementWithChildren = (
+          Component("1"),
+          children,
+          effects,
+          __globalContext^,
+        );
+        renderResult;
+      },
+    };
+    ret;
+  };
+
   module type COMPONENT = {
     type t;
     /* let derp: unit => unit; */
     let createElement: t;
   };
 
-  type func('a) = string => 'a;
+  type func('a) = renderFunction => 'a;
 
   let component2 = (type a, fn): (module COMPONENT with type t = a) => {
-      let boundFunc = fn("WOWEEEEE");
+      let boundFunc = fn(render2);
     (module {        
         type t = a;
         let createElement = boundFunc;

--- a/lib/Reactify.re
+++ b/lib/Reactify.re
@@ -196,7 +196,13 @@ module Make = (ReconcilerImpl: Reconciler) => {
     | None => ctx.initialValue
     };
 
-  let useEffect = (e: effect) => Effects.addEffect(__globalEffects, e);
+  let useEffect = (~condition: option('a)=?, e: effect) => {
+        switch (condition) {
+        | Some(_) => print_endline ("Some condition");
+        | None => print_endline ("No condition");
+        };
+        Effects.addEffect(__globalEffects, e);
+  };
 
   let _getEffectsFromInstance = (instance: option(instance)) =>
     switch (instance) {

--- a/lib/Reactify.re
+++ b/lib/Reactify.re
@@ -142,6 +142,18 @@ module Make = (ReconcilerImpl: Reconciler) => {
     ret;
   };
 
+  module type COMPONENT = {
+    type t;
+    let createElement: t;
+  };
+
+  let component2 = (type a, fn): (module COMPONENT with type t = a) => {
+    (module {
+        type t = a;
+        let createElement = fn;
+    }) 
+  };
+
   let primitiveComponent = (~children, prim) => {
     let comp: component = {
       element: Primitive(prim),

--- a/lib/Reactify.re
+++ b/lib/Reactify.re
@@ -45,7 +45,6 @@ module Make = (ReconcilerImpl: Reconciler) => {
   and container = {
     onBeginReconcile: Event.t(ReconcilerImpl.node),
     onEndReconcile: Event.t(ReconcilerImpl.node),
-
     rootInstance: ref(option(instance)),
     containerNode: ReconcilerImpl.node,
   }
@@ -86,35 +85,37 @@ module Make = (ReconcilerImpl: Reconciler) => {
    */
   type reconcileNotification = node => unit;
 
-  let createContainer = (~onBeginReconcile:option(reconcileNotification)=?, ~onEndReconcile:option(reconcileNotification)=?, rootNode: ReconcilerImpl.node) => {
-
+  let createContainer =
+      (
+        ~onBeginReconcile: option(reconcileNotification)=?,
+        ~onEndReconcile: option(reconcileNotification)=?,
+        rootNode: ReconcilerImpl.node,
+      ) => {
     let be = Event.create();
     let ee = Event.create();
 
     switch (onBeginReconcile) {
-    | Some(x) => 
-        let _ = Event.subscribe(be, x);
-        ();
+    | Some(x) =>
+      let _ = Event.subscribe(be, x);
+      ();
     | _ => ()
     };
 
     switch (onEndReconcile) {
-    | Some(x) => 
-        let _ = Event.subscribe(ee, x);
-        ();
+    | Some(x) =>
+      let _ = Event.subscribe(ee, x);
+      ();
     | _ => ()
     };
 
     let ret: container = {
-        onBeginReconcile: be,
-        onEndReconcile: ee,
-        containerNode: rootNode, 
-        rootInstance: ref(None)
+      onBeginReconcile: be,
+      onEndReconcile: ee,
+      containerNode: rootNode,
+      rootInstance: ref(None),
     };
 
-
     ret;
-
   };
 
   let empty: component = {
@@ -122,26 +123,28 @@ module Make = (ReconcilerImpl: Reconciler) => {
     render: () => (Empty, [], [], __globalContext^),
   };
 
-  type renderFunction = (~children:list(component)=?, componentFunction) => component;
-  let render: renderFunction = (~children:option(list(component))=?, c) => {
-    ignore(children);
-    let ret: component = {
-      element: Component("1"),
-      render: () => {
-        Effects.resetEffects(__globalEffects);
-        let children: list(component) = [c()];
-        let effects = Effects.getEffects(__globalEffects);
-        let renderResult: elementWithChildren = (
-          Component("1"),
-          children,
-          effects,
-          __globalContext^,
-        );
-        renderResult;
-      },
+  type renderFunction =
+    (~children: list(component)=?, componentFunction) => component;
+  let render: renderFunction =
+    (~children: option(list(component))=?, c) => {
+      ignore(children);
+      let ret: component = {
+        element: Component("1"),
+        render: () => {
+          Effects.resetEffects(__globalEffects);
+          let children: list(component) = [c()];
+          let effects = Effects.getEffects(__globalEffects);
+          let renderResult: elementWithChildren = (
+            Component("1"),
+            children,
+            effects,
+            __globalContext^,
+          );
+          renderResult;
+        },
+      };
+      ret;
     };
-    ret;
-  };
 
   module type Component = {
     type t;
@@ -152,11 +155,12 @@ module Make = (ReconcilerImpl: Reconciler) => {
   type func('a) = renderFunction => 'a;
 
   let component = (type a, fn): (module Component with type t = a) => {
-      let boundFunc = fn(render);
-    (module {        
-        type t = a;
-        let createElement = boundFunc;
-    }) 
+    let boundFunc = fn(render);
+    (module
+     {
+       type t = a;
+       let createElement = boundFunc;
+     });
   };
 
   let primitiveComponent = (~children, prim) => {
@@ -205,9 +209,13 @@ module Make = (ReconcilerImpl: Reconciler) => {
     | None => ctx.initialValue
     };
 
-  let useEffect = (~condition:Effects.effectCondition=Effects.Always, e: Effects.effectFunction) => {
-        Effects.addEffect(~condition=condition, __globalEffects, e);
-        ();
+  let useEffect =
+      (
+        ~condition: Effects.effectCondition=Effects.Always,
+        e: Effects.effectFunction,
+      ) => {
+    Effects.addEffect(~condition, __globalEffects, e);
+    ();
   };
 
   let _getEffectsFromInstance = (instance: option(instance)) =>
@@ -239,18 +247,17 @@ module Make = (ReconcilerImpl: Reconciler) => {
       }
     };
 
-  let isInstanceOfComponent = (instance: option(instance), component:component) => {
-    switch(instance) {
+  let isInstanceOfComponent =
+      (instance: option(instance), component: component) =>
+    switch (instance) {
     | None => false
-    | Some(x) => {
-        switch((x.component.element, component.element)) {
-        | (Primitive(a), Primitive(b)) =>  Utility.areConstructorsEqual(a, b)
-        | (Component(a), Component(b)) => a === b
-        | _ => x.component.element == component.element
-        }   
+    | Some(x) =>
+      switch (x.component.element, component.element) {
+      | (Primitive(a), Primitive(b)) => Utility.areConstructorsEqual(a, b)
+      | (Component(a), Component(b)) => a === b
+      | _ => x.component.element == component.element
+      }
     };
-    } 
-  }
 
   /*
    * Instantiate turns a component function into a live instance,
@@ -264,18 +271,18 @@ module Make = (ReconcilerImpl: Reconciler) => {
             context: Context.t,
             container: t,
           ) => {
-
     let previousState = ref([]);
-        
+
     /* Recycle any previous effect instances */
     let previousEffectInstances = _getEffectsFromInstance(previousInstance);
 
-    let isSameInstanceAsBefore = isInstanceOfComponent(previousInstance, component)
+    let isSameInstanceAsBefore =
+      isInstanceOfComponent(previousInstance, component);
 
     if (isSameInstanceAsBefore) {
-        /* Set up state for the component */
-        previousState := _getCurrentStateFromInstance(previousInstance);
-    }
+      /* Set up state for the component */
+      previousState := _getCurrentStateFromInstance(previousInstance);
+    };
 
     let state = ComponentState.create(previousState^);
     /* We hold onto a reference to the component instance - we need to set this _after_ the component is instantiated */
@@ -296,16 +303,18 @@ module Make = (ReconcilerImpl: Reconciler) => {
 
     let newEffectCount = List.length(effects);
 
-    let newEffectInstances = switch (isSameInstanceAsBefore) {
-    | true => {
-        Effects.runEffects(~previousInstances=previousEffectInstances, effects);    
-    }
-    | false => {
-        Effects.drainEffects(previousEffectInstances);
-        let emptyInstances = Effects.createEmptyEffectInstances(newEffectCount);
-        Effects.runEffects(~previousInstances=emptyInstances, effects);
-        }
-    }
+    let newEffectInstances =
+      isSameInstanceAsBefore ?
+        Effects.runEffects(
+          ~previousInstances=previousEffectInstances,
+          effects,
+        ) :
+        {
+          Effects.drainEffects(previousEffectInstances);
+          let emptyInstances =
+            Effects.createEmptyEffectInstances(newEffectCount);
+          Effects.runEffects(~previousInstances=emptyInstances, effects);
+        };
 
     let primitiveInstance =
       switch (element) {
@@ -338,7 +347,7 @@ module Make = (ReconcilerImpl: Reconciler) => {
       effectInstances: newEffectInstances,
       state: newState,
       context: newContext,
-      container: container,
+      container,
     };
 
     /*
@@ -351,7 +360,8 @@ module Make = (ReconcilerImpl: Reconciler) => {
     instance;
   }
   and reconcile = (rootNode, instance, component, context, container) => {
-    let newInstance = instantiate(rootNode, instance, component, context, container);
+    let newInstance =
+      instantiate(rootNode, instance, component, context, container);
 
     let r =
       switch (instance) {
@@ -482,7 +492,8 @@ module Make = (ReconcilerImpl: Reconciler) => {
       | Some(i) =>
         let {rootNode, component, _} = i;
         Event.dispatch(i.container.onBeginReconcile, rootNode);
-        let _ = reconcile(rootNode, Some(i), component, i.context, i.container);
+        let _ =
+          reconcile(rootNode, Some(i), component, i.context, i.container);
         Event.dispatch(i.container.onEndReconcile, rootNode);
         ();
       | _ => print_endline("WARNING: Skipping reconcile!")

--- a/lib/Reactify.re
+++ b/lib/Reactify.re
@@ -328,6 +328,7 @@ module Make = (ReconcilerImpl: Reconciler) => {
 
         newInstance;
       | Some(i) =>
+        i.effectInstances = newInstance.effectInstances;
         let ret =
           switch (newInstance.node, i.node) {
           | (Some(a), Some(b)) =>

--- a/lib/Reactify.re
+++ b/lib/Reactify.re
@@ -122,11 +122,7 @@ module Make = (ReconcilerImpl: Reconciler) => {
     render: () => (Empty, [], [], __globalContext^),
   };
 
-<<<<<<< HEAD
   let component = (~children: childComponents=[], ~uniqueId:string="", c: componentFunction) => {
-=======
-  let component = (~children: childComponents=[], ~uniqueId:string, c: componentFunction) => {
->>>>>>> master
     let ret: component = {
       element: Component(uniqueId),
       render: () => {
@@ -136,7 +132,6 @@ module Make = (ReconcilerImpl: Reconciler) => {
         let effects = Effects.getEffects(__globalEffects);
         let renderResult: elementWithChildren = (
           Component(uniqueId),
-<<<<<<< HEAD
           children,
           effects,
           __globalContext^,
@@ -158,8 +153,6 @@ module Make = (ReconcilerImpl: Reconciler) => {
         let effects = Effects.getEffects(__globalEffects);
         let renderResult: elementWithChildren = (
           Component("1"),
-=======
->>>>>>> master
           children,
           effects,
           __globalContext^,
@@ -296,16 +289,9 @@ module Make = (ReconcilerImpl: Reconciler) => {
         
     /* Recycle any previous effect instances */
     let previousEffectInstances = _getEffectsFromInstance(previousInstance);
-    /* Effects.runEffectInstances(previousEffectInstances); */
-<<<<<<< HEAD
 
     let isSameInstanceAsBefore = isInstanceOfComponent(previousInstance, component)
 
-=======
-
-    let isSameInstanceAsBefore = isInstanceOfComponent(previousInstance, component)
-
->>>>>>> master
     if (isSameInstanceAsBefore) {
         /* Set up state for the component */
         previousState := _getCurrentStateFromInstance(previousInstance);
@@ -332,17 +318,9 @@ module Make = (ReconcilerImpl: Reconciler) => {
 
     let newEffectInstances = switch (isSameInstanceAsBefore) {
     | true => {
-<<<<<<< HEAD
-        print_endline ("same instance");
         Effects.runEffects(~previousInstances=previousEffectInstances, effects);    
     }
     | false => {
-        print_endline ("different instance");
-=======
-        Effects.runEffects(~previousInstances=previousEffectInstances, effects);    
-    }
-    | false => {
->>>>>>> master
         Effects.drainEffects(previousEffectInstances);
         let emptyInstances = Effects.createEmptyEffectInstances(newEffectCount);
         Effects.runEffects(~previousInstances=emptyInstances, effects);

--- a/lib/Reactify.re
+++ b/lib/Reactify.re
@@ -148,10 +148,13 @@ module Make = (ReconcilerImpl: Reconciler) => {
     let createElement: t;
   };
 
+  type func('a) = string => 'a;
+
   let component2 = (type a, fn): (module COMPONENT with type t = a) => {
+      let boundFunc = fn("WOWEEEEE");
     (module {        
         type t = a;
-        let createElement = fn;
+        let createElement = boundFunc;
     }) 
   };
 

--- a/lib/Reactify.re
+++ b/lib/Reactify.re
@@ -122,7 +122,7 @@ module Make = (ReconcilerImpl: Reconciler) => {
     render: () => (Empty, [], [], __globalContext^),
   };
 
-  let component = (~children: childComponents=[], ~uniqueId:string="", c: componentFunction) => {
+  let component2 = (~children: childComponents=[], ~uniqueId:string="", c: componentFunction) => {
     let ret: component = {
       element: Component(uniqueId),
       render: () => {
@@ -171,7 +171,7 @@ module Make = (ReconcilerImpl: Reconciler) => {
 
   type func('a) = renderFunction => 'a;
 
-  let component2 = (type a, fn): (module COMPONENT with type t = a) => {
+  let component = (type a, fn): (module COMPONENT with type t = a) => {
       let boundFunc = fn(render2);
     (module {        
         type t = a;

--- a/lib/Reactify.re
+++ b/lib/Reactify.re
@@ -122,28 +122,8 @@ module Make = (ReconcilerImpl: Reconciler) => {
     render: () => (Empty, [], [], __globalContext^),
   };
 
-  let component2 = (~children: childComponents=[], ~uniqueId:string="", c: componentFunction) => {
-    let ret: component = {
-      element: Component(uniqueId),
-      render: () => {
-        Effects.resetEffects(__globalEffects);
-        let _dummy = children;
-        let children: list(component) = [c()];
-        let effects = Effects.getEffects(__globalEffects);
-        let renderResult: elementWithChildren = (
-          Component(uniqueId),
-          children,
-          effects,
-          __globalContext^,
-        );
-        renderResult;
-      },
-    };
-    ret;
-  };
-
   type renderFunction = (~children:list(component)=?, componentFunction) => component;
-  let render2: renderFunction = (~children:option(list(component))=?, c) => {
+  let render: renderFunction = (~children:option(list(component))=?, c) => {
     ignore(children);
     let ret: component = {
       element: Component("1"),
@@ -163,7 +143,7 @@ module Make = (ReconcilerImpl: Reconciler) => {
     ret;
   };
 
-  module type COMPONENT = {
+  module type Component = {
     type t;
     /* let derp: unit => unit; */
     let createElement: t;
@@ -171,8 +151,8 @@ module Make = (ReconcilerImpl: Reconciler) => {
 
   type func('a) = renderFunction => 'a;
 
-  let component = (type a, fn): (module COMPONENT with type t = a) => {
-      let boundFunc = fn(render2);
+  let component = (type a, fn): (module Component with type t = a) => {
+      let boundFunc = fn(render);
     (module {        
         type t = a;
         let createElement = boundFunc;

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -37,7 +37,12 @@ module type React = {
     | Empty
   and renderedElement =
     | RenderedPrimitive(node)
-  and elementWithChildren = (element, childComponents, Effects.effects, Context.t)
+  and elementWithChildren = (
+    element,
+    childComponents,
+    Effects.effects,
+    Context.t,
+  )
   /*
      A component is our JSX primitive element - just an object
      with a render method.
@@ -45,8 +50,8 @@ module type React = {
      a function of type unit => elementWithChildren ?
    */
   and component = {
-      element,
-      render: unit => elementWithChildren
+    element,
+    render: unit => elementWithChildren,
   }
   and componentFunction = unit => component
   and childComponents = list(component);
@@ -57,7 +62,13 @@ module type React = {
        Container API
    */
   type reconcileNotification = node => unit;
-  let createContainer: (~onBeginReconcile:reconcileNotification=?, ~onEndReconcile:reconcileNotification=?, node) => t;
+  let createContainer:
+    (
+      ~onBeginReconcile: reconcileNotification=?,
+      ~onEndReconcile: reconcileNotification=?,
+      node
+    ) =>
+    t;
   let updateContainer: (t, component) => unit;
 
   /*
@@ -71,16 +82,18 @@ module type React = {
     let createElement: t;
   };
 
-  type renderFunction = (~children:childComponents=?, componentFunction) => component;
+  type renderFunction =
+    (~children: childComponents=?, componentFunction) => component;
   type func('a) = renderFunction => 'a;
 
-  let component: (func('a)) => (module Component with type t = 'a);
+  let component: func('a) => (module Component with type t = 'a);
 
   /*
        Component API
    */
 
-  type providerConstructor('t) = (~children: childComponents, ~value: 't, unit) => component;
+  type providerConstructor('t) =
+    (~children: childComponents, ~value: 't, unit) => component;
   type context('t);
 
   let getProvider: context('t) => providerConstructor('t);
@@ -89,7 +102,8 @@ module type React = {
 
   let empty: component;
 
-  let useEffect: (~condition:Effects.effectCondition=?, Effects.effectFunction) => unit;
+  let useEffect:
+    (~condition: Effects.effectCondition=?, Effects.effectFunction) => unit;
 
   type stateUpdateFunction('t) = 't => unit;
   type stateResult('t) = ('t, stateUpdateFunction('t));

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -32,7 +32,7 @@ module type React = {
 
   type element =
     | Primitive(primitives)
-    | Component(string)
+    | Component(ComponentId.t)
     | Provider
     | Empty
   and renderedElement =

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -65,7 +65,7 @@ module type React = {
    */
   let primitiveComponent:
     (~children: childComponents, primitives) => component;
-  let component:
+  let component2:
     (~children: childComponents=?, ~uniqueId:string=?, componentFunction) => component;
 
   module type COMPONENT = {
@@ -76,7 +76,7 @@ module type React = {
   type renderFunction = (~children:childComponents=?, componentFunction) => component;
   type func('a) = renderFunction => 'a;
 
-  let component2: (func('a)) => (module COMPONENT with type t = 'a);
+  let component: (func('a)) => (module COMPONENT with type t = 'a);
 
   /*
        Component API

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -68,6 +68,13 @@ module type React = {
   let component:
     (~children: childComponents=?, ~uniqueId:string=?, componentFunction) => component;
 
+  module type COMPONENT = {
+    type t;
+    let createElement: t;
+  };
+
+  let component2: ('a) => (module COMPONENT with type t = 'a);
+
   /*
        Component API
    */

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -65,10 +65,8 @@ module type React = {
    */
   let primitiveComponent:
     (~children: childComponents, primitives) => component;
-  let component2:
-    (~children: childComponents=?, ~uniqueId:string=?, componentFunction) => component;
 
-  module type COMPONENT = {
+  module type Component = {
     type t;
     let createElement: t;
   };
@@ -76,7 +74,7 @@ module type React = {
   type renderFunction = (~children:childComponents=?, componentFunction) => component;
   type func('a) = renderFunction => 'a;
 
-  let component: (func('a)) => (module COMPONENT with type t = 'a);
+  let component: (func('a)) => (module Component with type t = 'a);
 
   /*
        Component API

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -73,7 +73,8 @@ module type React = {
     let createElement: t;
   };
 
-  type func('a) = string => 'a;
+  type renderFunction = (~children:childComponents=?, componentFunction) => component;
+  type func('a) = renderFunction => 'a;
 
   let component2: (func('a)) => (module COMPONENT with type t = 'a);
 

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -32,7 +32,7 @@ module type React = {
 
   type element =
     | Primitive(primitives)
-    | Component(componentFunction)
+    | Component(string)
     | Provider
     | Empty
   and renderedElement =
@@ -66,7 +66,7 @@ module type React = {
   let primitiveComponent:
     (~children: childComponents, primitives) => component;
   let component:
-    (~children: childComponents=?, componentFunction) => component;
+    (~children: childComponents=?, ~uniqueId:string=?, componentFunction) => component;
 
   /*
        Component API
@@ -81,7 +81,7 @@ module type React = {
 
   let empty: component;
 
-  let useEffect: (~condition:'a=?, Effects.effectFunction) => unit;
+  let useEffect: (~condition:Effects.effectCondition=?, Effects.effectFunction) => unit;
 
   type stateUpdateFunction('t) = 't => unit;
   type stateResult('t) = ('t, stateUpdateFunction('t));

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -73,7 +73,9 @@ module type React = {
     let createElement: t;
   };
 
-  let component2: ('a) => (module COMPONENT with type t = 'a);
+  type func('a) = string => 'a;
+
+  let component2: (func('a)) => (module COMPONENT with type t = 'a);
 
   /*
        Component API

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -85,7 +85,7 @@ module type React = {
 
   let empty: component;
 
-  let useEffect: effect => unit;
+  let useEffect: (~condition:'a=?, effect) => unit;
 
   type stateUpdateFunction('t) = 't => unit;
   type stateResult('t) = ('t, stateUpdateFunction('t));

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -66,7 +66,7 @@ module type React = {
   let primitiveComponent:
     (~children: childComponents, primitives) => component;
   let component:
-    (~children: childComponents=?, ~uniqueId:string, componentFunction) => component;
+    (~children: childComponents=?, ~uniqueId:string=?, componentFunction) => component;
 
   module type COMPONENT = {
     type t;

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -35,7 +35,7 @@ module type React = {
     | Component
   and renderedElement =
     | RenderedPrimitive(node)
-  and elementWithChildren = (element, childComponents, list(effect), Context.t)
+  and elementWithChildren = (element, childComponents, Effects.effects, Context.t)
   /*
      A component is our JSX primitive element - just an object
      with a render method.
@@ -46,12 +46,7 @@ module type React = {
       element,
       render: unit => elementWithChildren
   }
-  and childComponents = list(component)
-  and effectInstance = unit => unit
-  and effectInstances = list(effectInstance)
-  /* An effect is a function sent to useEffect. We haven't run it yet, */
-  /* But we will once the element is mounted */
-  and effect = unit => effectInstance;
+  and childComponents = list(component);
 
   type componentFunction = unit => component;
 
@@ -85,7 +80,7 @@ module type React = {
 
   let empty: component;
 
-  let useEffect: (~condition:'a=?, effect) => unit;
+  let useEffect: (~condition:'a=?, Effects.effectFunction) => unit;
 
   type stateUpdateFunction('t) = 't => unit;
   type stateResult('t) = ('t, stateUpdateFunction('t));

--- a/lib/State.re
+++ b/lib/State.re
@@ -1,72 +1,70 @@
 /*
- State - helper to convert any type of object to an opaque 'State.t'
+  State - helper to convert any type of object to an opaque 'State.t'
 
- This is _not ideal_ - we should be leveraging the magic of the OCaml type system,
- to help us here. We use this to assist in creating a heterogenous list of state,
- since `useState` can be called with any type, and we're preserving the semantics
- of the React hooks model.
+  This is _not ideal_ - we should be leveraging the magic of the OCaml type system,
+  to help us here. We use this to assist in creating a heterogenous list of state,
+  since `useState` can be called with any type, and we're preserving the semantics
+  of the React hooks model.
 
- There are other potential options - but they would require API changes.
+  There are other potential options - but they would require API changes.
 
- Definitely open to alternatives!
-*/
+  Definitely open to alternatives!
+ */
 
-module type StateContext = {
-    type t;
-};
+module type StateContext = {type t;};
 
-module HeterogenousMutableList {
-    type t = list(ref(Object.t));
+module HeterogenousMutableList = {
+  type t = list(ref(Object.t));
 
-    let create = () => [];
+  let create = () => [];
 };
 
 module Make = (StateContextImpl: StateContext) => {
-    type t = {
-        context: ref(ref(option(StateContextImpl.t))),
-        mutable currentState: HeterogenousMutableList.t,
-        mutable newState: HeterogenousMutableList.t,
+  type t = {
+    context: ref(ref(option(StateContextImpl.t))),
+    mutable currentState: HeterogenousMutableList.t,
+    mutable newState: HeterogenousMutableList.t,
+  };
+
+  type updateFunction('a) = 'a => unit;
+
+  let noneContext = () => ref(None);
+
+  let create = (previousState: HeterogenousMutableList.t) => {
+    let ret: t = {
+      context: ref(noneContext()),
+      currentState: previousState,
+      newState: HeterogenousMutableList.create(),
     };
+    ret;
+  };
 
-    type updateFunction('a) = 'a => unit;
-
-    let noneContext = () => {
-        ref(None);
-    };
-
-    let create = (previousState: HeterogenousMutableList.t) => {
-        let ret: t = {
-            context: ref(noneContext()),
-            currentState: previousState,
-            newState: HeterogenousMutableList.create(),
-        };
-        ret;
-    };
-
-    let popOldState: (t, 'a) => 'a = (state: t, defaultValue: 'a) => {
-        let curr = switch (state.currentState) {
+  let popOldState: (t, 'a) => 'a =
+    (state: t, defaultValue: 'a) => {
+      let curr =
+        switch (state.currentState) {
         | [] => defaultValue
-        | [hd, ...tail] => {
-            state.currentState = tail;
-            Object.of_object(hd^);
-        }
+        | [hd, ...tail] =>
+          state.currentState = tail;
+          Object.of_object(hd^);
         };
-        curr
+      curr;
     };
 
-    let pushNewState: (t, 'a) => updateFunction('a) = (state: t, currentVal: 'a) => {
-        let updatedVal: ref(Object.t) = ref(Object.to_object(currentVal));
-        state.newState = List.append(state.newState, [updatedVal]);
-        let ret: updateFunction('a) = (newVal: 'a) => {
-            updatedVal := Object.to_object(newVal);
-            ();
+  let pushNewState: (t, 'a) => updateFunction('a) =
+    (state: t, currentVal: 'a) => {
+      let updatedVal: ref(Object.t) = ref(Object.to_object(currentVal));
+      state.newState = List.append(state.newState, [updatedVal]);
+      let ret: updateFunction('a) =
+        (newVal: 'a) => {
+          updatedVal := Object.to_object(newVal);
+          ();
         };
-        ret;
+      ret;
     };
 
-    let getCurrentContext = (state: t) => state.context^;
+  let getCurrentContext = (state: t) => state.context^;
 
-    let getNewState: (t) => HeterogenousMutableList.t = (state: t) => {
-        state.newState
-    };
+  let getNewState: t => HeterogenousMutableList.t =
+    (state: t) => state.newState;
 };

--- a/lib/Utility.re
+++ b/lib/Utility.re
@@ -1,15 +1,15 @@
 /* Support methods for the library */
 
 /*
-    areConstructorsEqual
+     areConstructorsEqual
 
-    This is a helper method to check if two objects came from the same constructor.
-    The use of Obj.Magic is _not_ good and should be avoided, as it relies on internal
-    representation.
+     This is a helper method to check if two objects came from the same constructor.
+     The use of Obj.Magic is _not_ good and should be avoided, as it relies on internal
+     representation.
 
-    It looks like there are some smarter things we can do with the type system to handle this,
-    https://github.com/reasonml/reason-react/blob/a46fcda65f0847246a493bb2743f216010679b86/ReactMini/src/React.re#L422
-*/
+     It looks like there are some smarter things we can do with the type system to handle this,
+     https://github.com/reasonml/reason-react/blob/a46fcda65f0847246a493bb2743f216010679b86/ReactMini/src/React.re#L422
+ */
 
 let areConstructorsEqual = (x: 'a, y: 'a) => {
   let r = Obj.repr(x)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reason-reactify",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Reason workflow with Esy",
   "license": "MIT",
   "esy": {

--- a/test/ContainerTest.re
+++ b/test/ContainerTest.re
@@ -7,14 +7,16 @@ module Event = Reactify.Event;
 
 /* Use our Reconciler to create our own instance */
 module TestReact = Reactify.Make(TestReconciler);
+open TestReact;
+
 let createRootNode = () => {children: ref([]), nodeId: 0, nodeType: Root};
 
 let aComponent = (~testVal, ~children, ()) =>
-  TestReact.primitiveComponent(A(testVal), ~children);
+  primitiveComponent(A(testVal), ~children);
 let bComponent = (~children, ()) =>
-  TestReact.primitiveComponent(B, ~children);
+  primitiveComponent(B, ~children);
 let cComponent = (~children, ()) =>
-  TestReact.primitiveComponent(C, ~children);
+  primitiveComponent(C, ~children);
 
 test("Container", () => {
   test("beginReconcile / endReconcile are called for updateContainer", () => {
@@ -28,30 +30,29 @@ test("Container", () => {
     let onEndReconcile = _node => endCount := endCount^ + 1;
 
     let container =
-      TestReact.createContainer(~onBeginReconcile, ~onEndReconcile, rootNode);
+      createContainer(~onBeginReconcile, ~onEndReconcile, rootNode);
 
-    TestReact.updateContainer(container, <bComponent />);
+    updateContainer(container, <bComponent />);
 
     assert(beginCount^ == 1);
     assert(endCount^ == 1);
   });
 
-  let componentThatUpdatesState = (~children, ~event: Event.t(int), ()) =>
-    TestReact.component(
-      () => {
-        let (s, setS) = TestReact.useState(2);
+  module ComponentThatUpdatesState = (val component((render, ~children, ~event: Event.t(int), ()) => {
+      render(() => {
+        let (s, setS) = useState(2);
 
         print_endline("Value: " ++ string_of_int(s));
-        TestReact.useEffect(() => {
+        useEffect(() => {
           let unsubscribe = Event.subscribe(event, v => setS(v));
           () => unsubscribe();
         });
 
         <aComponent testVal=s />;
       },
-      ~uniqueId="componentThatUpdatesState",
-      ~children,
-    );
+      ~children
+      );
+  }));
 
   test("beginReconcile / endReconcile are called when updating state", () => {
     let rootNode = createRootNode();
@@ -64,10 +65,10 @@ test("Container", () => {
     let onEndReconcile = _node => endCount := endCount^ + 1;
 
     let container =
-      TestReact.createContainer(~onBeginReconcile, ~onEndReconcile, rootNode);
+      createContainer(~onBeginReconcile, ~onEndReconcile, rootNode);
 
     let event: Event.t(int) = Event.create();
-    TestReact.updateContainer(container, <componentThatUpdatesState event />);
+    updateContainer(container, <ComponentThatUpdatesState event />);
 
     beginCount := 0;
     endCount := 0;

--- a/test/ContainerTest.re
+++ b/test/ContainerTest.re
@@ -13,10 +13,8 @@ let createRootNode = () => {children: ref([]), nodeId: 0, nodeType: Root};
 
 let aComponent = (~testVal, ~children, ()) =>
   primitiveComponent(A(testVal), ~children);
-let bComponent = (~children, ()) =>
-  primitiveComponent(B, ~children);
-let cComponent = (~children, ()) =>
-  primitiveComponent(C, ~children);
+let bComponent = (~children, ()) => primitiveComponent(B, ~children);
+let cComponent = (~children, ()) => primitiveComponent(C, ~children);
 
 test("Container", () => {
   test("beginReconcile / endReconcile are called for updateContainer", () => {
@@ -38,21 +36,24 @@ test("Container", () => {
     assert(endCount^ == 1);
   });
 
-  module ComponentThatUpdatesState = (val component((render, ~children, ~event: Event.t(int), ()) => {
-      render(() => {
-        let (s, setS) = useState(2);
+  module ComponentThatUpdatesState = (
+    val component((render, ~children, ~event: Event.t(int), ()) =>
+          render(
+            () => {
+              let (s, setS) = useState(2);
 
-        print_endline("Value: " ++ string_of_int(s));
-        useEffect(() => {
-          let unsubscribe = Event.subscribe(event, v => setS(v));
-          () => unsubscribe();
-        });
+              print_endline("Value: " ++ string_of_int(s));
+              useEffect(() => {
+                let unsubscribe = Event.subscribe(event, v => setS(v));
+                () => unsubscribe();
+              });
 
-        <aComponent testVal=s />;
-      },
-      ~children
-      );
-  }));
+              <aComponent testVal=s />;
+            },
+            ~children,
+          )
+        )
+  );
 
   test("beginReconcile / endReconcile are called when updating state", () => {
     let rootNode = createRootNode();

--- a/test/HooksUseContextTest.re
+++ b/test/HooksUseContextTest.re
@@ -14,10 +14,8 @@ let createRootNode = () => {children: ref([]), nodeId: 0, nodeType: Root};
 
 let aComponent = (~testVal, ~children, ()) =>
   primitiveComponent(A(testVal), ~children);
-let bComponent = (~children, ()) =>
-  primitiveComponent(B, ~children);
-let cComponent = (~children, ()) =>
-  primitiveComponent(C, ~children);
+let bComponent = (~children, ()) => primitiveComponent(B, ~children);
+let cComponent = (~children, ()) => primitiveComponent(C, ~children);
 
 test("HooksUseContext", () => {
   test("uses default value", () => {
@@ -26,14 +24,18 @@ test("HooksUseContext", () => {
 
     let testContext = createContext(2);
 
-    module ComponentThatUsesContext = (val component((render, ~children, ()) => {
-        render(() => {
-          let ctx = useContext(testContext);
+    module ComponentThatUsesContext = (
+      val component((render, ~children, ()) =>
+            render(
+              () => {
+                let ctx = useContext(testContext);
 
-          <aComponent testVal=ctx />;
-        },
-        ~children);
-    }));
+                <aComponent testVal=ctx />;
+              },
+              ~children,
+            )
+          )
+    );
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(2))]);
@@ -49,14 +51,18 @@ test("HooksUseContext", () => {
     let testContext = createContext(2);
     let provider = getProvider(testContext);
 
-    module ComponentThatUsesContext = (val component((render, ~children, ()) => {
-        render(() => {
-          let ctx = useContext(testContext);
+    module ComponentThatUsesContext = (
+      val component((render, ~children, ()) =>
+            render(
+              () => {
+                let ctx = useContext(testContext);
 
-          <provider value=9> <aComponent testVal=ctx /> </provider>;
-        },
-        ~children);
-    }));
+                <provider value=9> <aComponent testVal=ctx /> </provider>;
+              },
+              ~children,
+            )
+          )
+    );
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(2))]);
@@ -72,13 +78,17 @@ test("HooksUseContext", () => {
     let testContext = createContext(2);
     let provider = getProvider(testContext);
 
-    module ComponentThatUsesContext = (val component((render, ~children, ()) => {
-        render(() => {
-          let ctx = useContext(testContext);
-          <aComponent testVal=ctx />;
-        },
-        ~children);
-    }));
+    module ComponentThatUsesContext = (
+      val component((render, ~children, ()) =>
+            render(
+              () => {
+                let ctx = useContext(testContext);
+                <aComponent testVal=ctx />;
+              },
+              ~children,
+            )
+          )
+    );
 
     updateContainer(
       container,

--- a/test/HooksUseContextTest.re
+++ b/test/HooksUseContextTest.re
@@ -8,87 +8,82 @@ module Event = Reactify.Event;
 
 /* Use our Reconciler to create our own instance */
 module TestReact = Reactify.Make(TestReconciler);
+open TestReact;
 
 let createRootNode = () => {children: ref([]), nodeId: 0, nodeType: Root};
 
 let aComponent = (~testVal, ~children, ()) =>
-  TestReact.primitiveComponent(A(testVal), ~children);
+  primitiveComponent(A(testVal), ~children);
 let bComponent = (~children, ()) =>
-  TestReact.primitiveComponent(B, ~children);
+  primitiveComponent(B, ~children);
 let cComponent = (~children, ()) =>
-  TestReact.primitiveComponent(C, ~children);
+  primitiveComponent(C, ~children);
 
 test("HooksUseContext", () => {
   test("uses default value", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
-    let testContext = TestReact.createContext(2);
+    let testContext = createContext(2);
 
-    let componentThatUsesContext = (~children, ()) =>
-      TestReact.component(
-        () => {
-          let ctx = TestReact.useContext(testContext);
+    module ComponentThatUsesContext = (val component((render, ~children, ()) => {
+        render(() => {
+          let ctx = useContext(testContext);
 
           <aComponent testVal=ctx />;
         },
-        ~uniqueId="componentThatUsesContext",
-        ~children,
-      );
+        ~children);
+    }));
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(2))]);
 
-    TestReact.updateContainer(container, <componentThatUsesContext />);
+    updateContainer(container, <ComponentThatUsesContext />);
     validateStructure(rootNode, expectedStructure);
   });
 
   test("uses provider value", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
-    let testContext = TestReact.createContext(2);
-    let provider = TestReact.getProvider(testContext);
+    let testContext = createContext(2);
+    let provider = getProvider(testContext);
 
-    let componentThatUsesContext = (~children, ()) =>
-      TestReact.component(
-        () => {
-          let ctx = TestReact.useContext(testContext);
+    module ComponentThatUsesContext = (val component((render, ~children, ()) => {
+        render(() => {
+          let ctx = useContext(testContext);
 
           <provider value=9> <aComponent testVal=ctx /> </provider>;
         },
-        ~uniqueId="componentThatUsesContext",
-        ~children,
-      );
+        ~children);
+    }));
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(2))]);
 
-    TestReact.updateContainer(container, <componentThatUsesContext />);
+    updateContainer(container, <ComponentThatUsesContext />);
     validateStructure(rootNode, expectedStructure);
   });
 
   test("uses nested provider value", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
-    let testContext = TestReact.createContext(2);
-    let provider = TestReact.getProvider(testContext);
+    let testContext = createContext(2);
+    let provider = getProvider(testContext);
 
-    let componentThatUsesContext = (~children, ()) =>
-      TestReact.component(
-        () => {
-          let ctx = TestReact.useContext(testContext);
+    module ComponentThatUsesContext = (val component((render, ~children, ()) => {
+        render(() => {
+          let ctx = useContext(testContext);
           <aComponent testVal=ctx />;
         },
-        ~uniqueId="componentThatUsesContext",
-        ~children,
-      );
+        ~children);
+    }));
 
-    TestReact.updateContainer(
+    updateContainer(
       container,
       <provider value=9>
-        <provider value=10> <componentThatUsesContext /> </provider>
+        <provider value=10> <ComponentThatUsesContext /> </provider>
       </provider>,
     );
 

--- a/test/HooksUseEffectTest.re
+++ b/test/HooksUseEffectTest.re
@@ -32,6 +32,20 @@ let componentWithEffectOnMount =
     ~children,
   );
 
+let componentWithEmptyConditionalEffect =
+    (~children, ~functionToCallOnMount, ~functionToCallOnUnmount, ()) =>
+  TestReact.component(
+    () => {
+      TestReact.useEffect(~condition=[], () => {
+        functionToCallOnMount();
+        () => functionToCallOnUnmount();
+      });
+
+      <bComponent />;
+    },
+    ~children,
+  );
+
 test("useEffect", () => {
   test("useEffect is called on render", () => {
     let rootNode = createRootNode();
@@ -81,5 +95,55 @@ test("useEffect", () => {
     validateStructure(rootNode, expectedStructure);
     assert(v^ == 1);
     assert(r^ == 1);
+  });
+
+  test("useEffect without a condition is called for each render", () => {
+    let rootNode = createRootNode();
+    let container = TestReact.createContainer(rootNode);
+
+    let v = ref(0);
+    let mutate = () => v := v^ + 1;
+
+    TestReact.updateContainer(
+      container,
+      <componentWithEffectOnMount
+        functionToCallOnMount=mutate
+        functionToCallOnUnmount=noop
+      />,
+    );
+    TestReact.updateContainer(
+      container,
+      <componentWithEffectOnMount
+        functionToCallOnMount=mutate
+        functionToCallOnUnmount=noop
+      />,
+    );
+
+    assert(v^ == 2);
+  });
+
+  test("useEffect with an empty condition is called only once", () => {
+    let rootNode = createRootNode();
+    let container = TestReact.createContainer(rootNode);
+
+    let v = ref(0);
+    let mutate = () => v := v^ + 1;
+
+    TestReact.updateContainer(
+      container,
+      <componentWithEmptyConditionalEffect
+        functionToCallOnMount=mutate
+        functionToCallOnUnmount=noop
+      />,
+    );
+    TestReact.updateContainer(
+      container,
+      <componentWithEmptyConditionalEffect
+        functionToCallOnMount=mutate
+        functionToCallOnUnmount=noop
+      />,
+    );
+
+    assert(v^ == 1);
   });
 });

--- a/test/HooksUseEffectTest.re
+++ b/test/HooksUseEffectTest.re
@@ -29,6 +29,7 @@ let componentWithEffectOnMount =
 
       <bComponent />;
     },
+    ~uniqueId="componentWithEffectOnMount",
     ~children,
   );
 
@@ -36,13 +37,14 @@ let componentWithEmptyConditionalEffect =
     (~children, ~functionToCallOnMount, ~functionToCallOnUnmount, ()) =>
   TestReact.component(
     () => {
-      TestReact.useEffect(~condition=[], () => {
+      TestReact.useEffect(~condition=MountUnmount, () => {
         functionToCallOnMount();
         () => functionToCallOnUnmount();
       });
 
       <bComponent />;
     },
+    ~uniqueId="componentWithEmptyConditionalEffect",
     ~children,
   );
 
@@ -91,9 +93,7 @@ test("useEffect", () => {
     validateStructure(rootNode, expectedStructure);
     assert(v^ == 1);
 
-    print_endline("** START REMOVING")
     TestReact.updateContainer(container, <bComponent />);
-    print_endline("** END REMOVING")
     validateStructure(rootNode, expectedStructure);
     assert(v^ == 1);
     assert(r^ == 1);
@@ -138,6 +138,7 @@ test("useEffect", () => {
         functionToCallOnUnmount=noop
       />,
     );
+    print_endline ("** SECOND UPDATE **");
     TestReact.updateContainer(
       container,
       <componentWithEmptyConditionalEffect
@@ -145,7 +146,8 @@ test("useEffect", () => {
         functionToCallOnUnmount=noop
       />,
     );
+    print_endline ("** SECOND UPDATE **");
 
-    assert(v^ == 1);
+    expect(v^).toBe(1);
   });
 });

--- a/test/HooksUseEffectTest.re
+++ b/test/HooksUseEffectTest.re
@@ -12,39 +12,63 @@ let createRootNode = () => {children: ref([]), nodeId: 0, nodeType: Root};
 
 let aComponent = (~testVal, ~children, ()) =>
   primitiveComponent(A(testVal), ~children);
-let bComponent = (~children, ()) =>
-  primitiveComponent(B, ~children);
-let cComponent = (~children, ()) =>
-  primitiveComponent(C, ~children);
+let bComponent = (~children, ()) => primitiveComponent(B, ~children);
+let cComponent = (~children, ()) => primitiveComponent(C, ~children);
 
 let noop = () => ();
 
-module ComponentWithEffectOnMount = (val component((render, ~children, ~functionToCallOnMount, ~functionToCallOnUnmount, ()) => {
-   render(() => {
-      /* Hooks */
-      useEffect(() => {
-        functionToCallOnMount();
-        () => functionToCallOnUnmount();
-      });
-      /* End Hooks */
+module ComponentWithEffectOnMount = (
+  val component(
+        (
+          render,
+          ~children,
+          ~functionToCallOnMount,
+          ~functionToCallOnUnmount,
+          (),
+        ) =>
+        render(
+          () => {
+            /* Hooks */
+            useEffect(() => {
+              functionToCallOnMount();
+              () => functionToCallOnUnmount();
+            });
+            /* End Hooks */
 
-      <bComponent />;
-   }, ~children); 
-}));
+            <bComponent />;
+          },
+          ~children,
+        )
+      )
+);
 
-module ComponentWithEmptyConditionalEffect = (val component((render, ~children, ~functionToCallOnMount, ~functionToCallOnUnmount, ()) => {
-   render(() => {
-      /* Hooks */
-      useEffect(~condition=MountUnmount, () => {
-        functionToCallOnMount();
-        () => functionToCallOnUnmount();
-      });
-      /* End Hooks */
+module ComponentWithEmptyConditionalEffect = (
+  val component(
+        (
+          render,
+          ~children,
+          ~functionToCallOnMount,
+          ~functionToCallOnUnmount,
+          (),
+        ) =>
+        render(
+          () => {
+            /* Hooks */
+            useEffect(
+              ~condition=MountUnmount,
+              () => {
+                functionToCallOnMount();
+                () => functionToCallOnUnmount();
+              },
+            );
+            /* End Hooks */
 
-      <bComponent />;
-    },
-    ~children);
-}));
+            <bComponent />;
+          },
+          ~children,
+        )
+      )
+);
 
 test("useEffect", () => {
   test("useEffect is called on render", () => {

--- a/test/HooksUseEffectTest.re
+++ b/test/HooksUseEffectTest.re
@@ -6,52 +6,50 @@ open TestUtility;
 
 /* Use our Reconciler to create our own instance */
 module TestReact = Reactify.Make(TestReconciler);
+open TestReact;
 
 let createRootNode = () => {children: ref([]), nodeId: 0, nodeType: Root};
 
 let aComponent = (~testVal, ~children, ()) =>
-  TestReact.primitiveComponent(A(testVal), ~children);
+  primitiveComponent(A(testVal), ~children);
 let bComponent = (~children, ()) =>
-  TestReact.primitiveComponent(B, ~children);
+  primitiveComponent(B, ~children);
 let cComponent = (~children, ()) =>
-  TestReact.primitiveComponent(C, ~children);
+  primitiveComponent(C, ~children);
 
 let noop = () => ();
 
-let componentWithEffectOnMount =
-    (~children, ~functionToCallOnMount, ~functionToCallOnUnmount, ()) =>
-  TestReact.component(
-    () => {
-      TestReact.useEffect(() => {
+module ComponentWithEffectOnMount = (val component((render, ~children, ~functionToCallOnMount, ~functionToCallOnUnmount, ()) => {
+   render(() => {
+      /* Hooks */
+      useEffect(() => {
         functionToCallOnMount();
         () => functionToCallOnUnmount();
       });
+      /* End Hooks */
 
       <bComponent />;
-    },
-    ~uniqueId="componentWithEffectOnMount",
-    ~children,
-  );
+   }, ~children); 
+}));
 
-let componentWithEmptyConditionalEffect =
-    (~children, ~functionToCallOnMount, ~functionToCallOnUnmount, ()) =>
-  TestReact.component(
-    () => {
-      TestReact.useEffect(~condition=MountUnmount, () => {
+module ComponentWithEmptyConditionalEffect = (val component((render, ~children, ~functionToCallOnMount, ~functionToCallOnUnmount, ()) => {
+   render(() => {
+      /* Hooks */
+      useEffect(~condition=MountUnmount, () => {
         functionToCallOnMount();
         () => functionToCallOnUnmount();
       });
+      /* End Hooks */
 
       <bComponent />;
     },
-    ~uniqueId="componentWithEmptyConditionalEffect",
-    ~children,
-  );
+    ~children);
+}));
 
 test("useEffect", () => {
   test("useEffect is called on render", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let v = ref(0);
     let mutate = () => v := v^ + 1;
@@ -59,9 +57,9 @@ test("useEffect", () => {
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(B)]);
 
-    TestReact.updateContainer(
+    updateContainer(
       container,
-      <componentWithEffectOnMount
+      <ComponentWithEffectOnMount
         functionToCallOnMount=mutate
         functionToCallOnUnmount=noop
       />,
@@ -73,7 +71,7 @@ test("useEffect", () => {
 
   test("useEffect handles case when component is removed", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let v = ref(0);
     let r = ref(0);
@@ -83,9 +81,9 @@ test("useEffect", () => {
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(B)]);
 
-    TestReact.updateContainer(
+    updateContainer(
       container,
-      <componentWithEffectOnMount
+      <ComponentWithEffectOnMount
         functionToCallOnMount=mount
         functionToCallOnUnmount=unmount
       />,
@@ -93,7 +91,7 @@ test("useEffect", () => {
     validateStructure(rootNode, expectedStructure);
     assert(v^ == 1);
 
-    TestReact.updateContainer(container, <bComponent />);
+    updateContainer(container, <bComponent />);
     validateStructure(rootNode, expectedStructure);
     assert(v^ == 1);
     assert(r^ == 1);
@@ -101,21 +99,21 @@ test("useEffect", () => {
 
   test("useEffect without a condition is called for each render", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let v = ref(0);
     let mutate = () => v := v^ + 1;
 
-    TestReact.updateContainer(
+    updateContainer(
       container,
-      <componentWithEffectOnMount
+      <ComponentWithEffectOnMount
         functionToCallOnMount=mutate
         functionToCallOnUnmount=noop
       />,
     );
-    TestReact.updateContainer(
+    updateContainer(
       container,
-      <componentWithEffectOnMount
+      <ComponentWithEffectOnMount
         functionToCallOnMount=mutate
         functionToCallOnUnmount=noop
       />,
@@ -126,21 +124,21 @@ test("useEffect", () => {
 
   test("useEffect with an empty condition is called only once", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let v = ref(0);
     let mutate = () => v := v^ + 1;
 
-    TestReact.updateContainer(
+    updateContainer(
       container,
-      <componentWithEmptyConditionalEffect
+      <ComponentWithEmptyConditionalEffect
         functionToCallOnMount=mutate
         functionToCallOnUnmount=noop
       />,
     );
-    TestReact.updateContainer(
+    updateContainer(
       container,
-      <componentWithEmptyConditionalEffect
+      <ComponentWithEmptyConditionalEffect
         functionToCallOnMount=mutate
         functionToCallOnUnmount=noop
       />,

--- a/test/HooksUseEffectTest.re
+++ b/test/HooksUseEffectTest.re
@@ -91,7 +91,9 @@ test("useEffect", () => {
     validateStructure(rootNode, expectedStructure);
     assert(v^ == 1);
 
+    print_endline("** START REMOVING")
     TestReact.updateContainer(container, <bComponent />);
+    print_endline("** END REMOVING")
     validateStructure(rootNode, expectedStructure);
     assert(v^ == 1);
     assert(r^ == 1);

--- a/test/HooksUseStateTest.re
+++ b/test/HooksUseStateTest.re
@@ -24,6 +24,7 @@ let componentWithState = (~children, ()) =>
       let (s, _setS) = TestReact.useState(2);
       <aComponent testVal=s />;
     },
+    ~uniqueId="componentWithState",
     ~children,
   );
 
@@ -58,6 +59,7 @@ test("useState", () => {
 
         <aComponent testVal=s />;
       },
+      ~uniqueId="componentThatUpdatesState",
       ~children,
     );
 
@@ -98,6 +100,28 @@ test("useState", () => {
     /* and not pick up the state from the previous component */
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(2))]);
+    validateStructure(rootNode, expectedStructure);
+  });
+
+  test("useState set state persists across renders", () => {
+    let rootNode = createRootNode();
+
+    let container = TestReact.createContainer(rootNode);
+
+    let event: Event.t(int) = Event.create();
+
+    TestReact.updateContainer(container, <componentThatUpdatesState event />);
+
+    Event.dispatch(event, 5);
+
+    let expectedStructure: tree(primitives) =
+      TreeNode(Root, [TreeLeaf(A(5))]);
+    validateStructure(rootNode, expectedStructure);
+
+    TestReact.updateContainer(container, <componentThatUpdatesState event />);
+
+    let expectedStructure: tree(primitives) =
+      TreeNode(Root, [TreeLeaf(A(5))]);
     validateStructure(rootNode, expectedStructure);
   });
 

--- a/test/HooksUseStateTest.re
+++ b/test/HooksUseStateTest.re
@@ -8,69 +8,68 @@ module Event = Reactify.Event;
 
 /* Use our Reconciler to create our own instance */
 module TestReact = Reactify.Make(TestReconciler);
+open TestReact;
 
 let createRootNode = () => {children: ref([]), nodeId: 0, nodeType: Root};
 
 let aComponent = (~testVal, ~children, ()) =>
-  TestReact.primitiveComponent(A(testVal), ~children);
+  primitiveComponent(A(testVal), ~children);
 let bComponent = (~children, ()) =>
-  TestReact.primitiveComponent(B, ~children);
+  primitiveComponent(B, ~children);
 let cComponent = (~children, ()) =>
-  TestReact.primitiveComponent(C, ~children);
+  primitiveComponent(C, ~children);
 
-let componentWithState = (~children, ()) =>
-  TestReact.component(
-    () => {
-      let (s, _setS) = TestReact.useState(2);
+module ComponentWithState = (val component((render, ~children, ()) => {
+    render(() => {
+      /* Hooks */
+      let (s, _setS) = useState(2);
+      /* End hooks */
+
       <aComponent testVal=s />;
-    },
-    ~uniqueId="componentWithState",
-    ~children,
-  );
+    }, ~children);
+}))
 
 type renderOption =
   /* | Nothing */
-  | ComponentWithState
-  | AComponent(int);
+  | RenderAComponentWithState
+  | RenderAComponent(int);
 
 test("useState", () => {
   test("useState uses initial state", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(2))]);
 
-    TestReact.updateContainer(container, <componentWithState />);
+    updateContainer(container, <ComponentWithState />);
 
     validateStructure(rootNode, expectedStructure);
   });
 
-  let componentThatUpdatesState = (~children, ~event: Event.t(int), ()) =>
-    TestReact.component(
-      () => {
-        let (s, setS) = TestReact.useState(2);
+  module ComponentThatUpdatesState = (val component((render, ~children, ~event: Event.t(int), ()) => {
+      render(() => {
+        /* Hooks */
+        let (s, setS) = useState(2);
+        /* End hooks */
 
-        print_endline("Value: " ++ string_of_int(s));
-        TestReact.useEffect(() => {
+        useEffect(() => {
           let unsubscribe = Event.subscribe(event, v => setS(v));
           () => unsubscribe();
         });
 
         <aComponent testVal=s />;
-      },
-      ~uniqueId="componentThatUpdatesState",
-      ~children,
-    );
+      }, ~children);
+  }));
 
   test("useState updates state with set function", () => {
     let rootNode = createRootNode();
 
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let event: Event.t(int) = Event.create();
 
-    TestReact.updateContainer(container, <componentThatUpdatesState event />);
+    updateContainer(container, <ComponentThatUpdatesState event />);
 
     Event.dispatch(event, 5);
 
@@ -82,11 +81,11 @@ test("useState", () => {
   test("useState doesn't leak state between components", () => {
     let rootNode = createRootNode();
 
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let event: Event.t(int) = Event.create();
 
-    TestReact.updateContainer(container, <componentThatUpdatesState event />);
+    updateContainer(container, <ComponentThatUpdatesState event />);
 
     Event.dispatch(event, 5);
 
@@ -94,7 +93,7 @@ test("useState", () => {
       TreeNode(Root, [TreeLeaf(A(5))]);
     validateStructure(rootNode, expectedStructure);
 
-    TestReact.updateContainer(container, <componentWithState />);
+    updateContainer(container, <ComponentWithState />);
 
     /* The 'componentWithState' should have its own state, so it should revert back to 2 - */
     /* and not pick up the state from the previous component */
@@ -106,11 +105,11 @@ test("useState", () => {
   test("useState set state persists across renders", () => {
     let rootNode = createRootNode();
 
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let event: Event.t(int) = Event.create();
 
-    TestReact.updateContainer(container, <componentThatUpdatesState event />);
+    updateContainer(container, <ComponentThatUpdatesState event />);
 
     Event.dispatch(event, 5);
 
@@ -118,7 +117,7 @@ test("useState", () => {
       TreeNode(Root, [TreeLeaf(A(5))]);
     validateStructure(rootNode, expectedStructure);
 
-    TestReact.updateContainer(container, <componentThatUpdatesState event />);
+    updateContainer(container, <ComponentThatUpdatesState event />);
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(5))]);
@@ -127,11 +126,11 @@ test("useState", () => {
 
   test("useState can update multiple times", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let event: Event.t(int) = Event.create();
 
-    TestReact.updateContainer(container, <componentThatUpdatesState event />);
+    updateContainer(container, <ComponentThatUpdatesState event />);
 
     Event.dispatch(event, 5);
     let expectedStructure: tree(primitives) =
@@ -149,36 +148,33 @@ test("useState", () => {
     validateStructure(rootNode, expectedStructure);
   });
 
-  let componentThatUpdatesStateAndRendersChildren =
-      (~children, ~event: Event.t(int), ()) =>
-    TestReact.component(
-      () => {
-        let (s, setS) = TestReact.useState(2);
-
-        print_endline("Value: " ++ string_of_int(s));
-        TestReact.useEffect(() => {
+  module ComponentThatUpdatesStateAndRendersChildren = (val component((render, ~children, ~event: Event.t(int), ()) => {
+    render(() => {
+        /* Hooks */
+        let (s, setS) = useState(2);
+        
+        useEffect(() => {
           let unsubscribe = Event.subscribe(event, v => setS(v));
           () => unsubscribe();
         });
+        /* End Hooks */
 
         <aComponent testVal=s> ...children </aComponent>;
-      },
-      ~uniqueId="componentThatUpdatesStateAndRendersChildren",
-      ~children,
-    );
+    }, ~children);
+  }));
 
   test("nested state works as expected", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let outerEvent = Event.create();
     let innerEvent = Event.create();
 
-    TestReact.updateContainer(
+    updateContainer(
       container,
-      <componentThatUpdatesStateAndRendersChildren event=outerEvent>
-        <componentThatUpdatesState event=innerEvent />
-      </componentThatUpdatesStateAndRendersChildren>,
+      <ComponentThatUpdatesStateAndRendersChildren event=outerEvent>
+        <ComponentThatUpdatesState event=innerEvent />
+      </ComponentThatUpdatesStateAndRendersChildren>,
     );
 
     let expectedStructure: tree(primitives) =
@@ -201,52 +197,55 @@ test("useState", () => {
     validateStructure(rootNode, expectedStructure);
   });
 
-  let componentThatWrapsEitherPrimitiveOrComponent =
-      (~children, ~event: Event.t(renderOption), ()) =>
-    TestReact.component(
-      () => {
-        let (s, setS) = TestReact.useState(ComponentWithState);
 
-        TestReact.useEffect(() => {
-          let unsubscribe = Event.subscribe(event, v => setS(v));
-          () => unsubscribe();
-        });
+module ComponentThatWrapsEitherPrimitiveOrComponent = (val component(
+    (render, ~children, ~event: Event.t(renderOption), ()) => {
+        render(() => {
+            
+            /* Hooks */
+            let (s, setS) = useState(RenderAComponentWithState);
 
-        switch (s) {
-        /* | Nothing => () */
-        | ComponentWithState => <componentWithState />
-        | AComponent(x) => <aComponent testVal=x />
-        };
-      },
-      ~uniqueId="componentThatWrapsEitherPrimitiveOrComponent",
-      ~children,
-    );
+            useEffect(() => {
+              let unsubscribe = Event.subscribe(event, v => setS(v));
+              () => unsubscribe();
+            });
+            /* End Hook */
+
+            switch (s) {
+            /* | Nothing => () */
+            | RenderAComponentWithState => <ComponentWithState />
+            | RenderAComponent(x) => <aComponent testVal=x />
+            };
+        },
+        ~children);
+    })
+);
 
   test("switching between a component to a primitive and back works", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let boolEvent: Event.t(renderOption) = Event.create();
-    TestReact.updateContainer(
+    updateContainer(
       container,
-      <componentThatWrapsEitherPrimitiveOrComponent event=boolEvent />,
+      <ComponentThatWrapsEitherPrimitiveOrComponent event=boolEvent />,
     );
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(2))]);
     validateStructure(rootNode, expectedStructure);
 
-    Event.dispatch(boolEvent, AComponent(3));
+    Event.dispatch(boolEvent, RenderAComponent(3));
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(3))]);
     validateStructure(rootNode, expectedStructure);
 
-    Event.dispatch(boolEvent, ComponentWithState);
+    Event.dispatch(boolEvent, RenderAComponentWithState);
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(2))]);
     validateStructure(rootNode, expectedStructure);
 
-    Event.dispatch(boolEvent, AComponent(5));
+    Event.dispatch(boolEvent, RenderAComponent(5));
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(5))]);
     validateStructure(rootNode, expectedStructure);

--- a/test/HooksUseStateTest.re
+++ b/test/HooksUseStateTest.re
@@ -14,20 +14,23 @@ let createRootNode = () => {children: ref([]), nodeId: 0, nodeType: Root};
 
 let aComponent = (~testVal, ~children, ()) =>
   primitiveComponent(A(testVal), ~children);
-let bComponent = (~children, ()) =>
-  primitiveComponent(B, ~children);
-let cComponent = (~children, ()) =>
-  primitiveComponent(C, ~children);
+let bComponent = (~children, ()) => primitiveComponent(B, ~children);
+let cComponent = (~children, ()) => primitiveComponent(C, ~children);
 
-module ComponentWithState = (val component((render, ~children, ()) => {
-    render(() => {
-      /* Hooks */
-      let (s, _setS) = useState(2);
-      /* End hooks */
+module ComponentWithState = (
+  val component((render, ~children, ()) =>
+        render(
+          () => {
+            /* Hooks */
+            let (s, _setS) = useState(2);
+            /* End hooks */
 
-      <aComponent testVal=s />;
-    }, ~children);
-}))
+            <aComponent testVal=s />;
+          },
+          ~children,
+        )
+      )
+);
 
 type renderOption =
   /* | Nothing */
@@ -47,20 +50,25 @@ test("useState", () => {
     validateStructure(rootNode, expectedStructure);
   });
 
-  module ComponentThatUpdatesState = (val component((render, ~children, ~event: Event.t(int), ()) => {
-      render(() => {
-        /* Hooks */
-        let (s, setS) = useState(2);
-        /* End hooks */
+  module ComponentThatUpdatesState = (
+    val component((render, ~children, ~event: Event.t(int), ()) =>
+          render(
+            () => {
+              /* Hooks */
+              let (s, setS) = useState(2);
+              /* End hooks */
 
-        useEffect(() => {
-          let unsubscribe = Event.subscribe(event, v => setS(v));
-          () => unsubscribe();
-        });
+              useEffect(() => {
+                let unsubscribe = Event.subscribe(event, v => setS(v));
+                () => unsubscribe();
+              });
 
-        <aComponent testVal=s />;
-      }, ~children);
-  }));
+              <aComponent testVal=s />;
+            },
+            ~children,
+          )
+        )
+  );
 
   test("useState updates state with set function", () => {
     let rootNode = createRootNode();
@@ -148,20 +156,25 @@ test("useState", () => {
     validateStructure(rootNode, expectedStructure);
   });
 
-  module ComponentThatUpdatesStateAndRendersChildren = (val component((render, ~children, ~event: Event.t(int), ()) => {
-    render(() => {
-        /* Hooks */
-        let (s, setS) = useState(2);
-        
-        useEffect(() => {
-          let unsubscribe = Event.subscribe(event, v => setS(v));
-          () => unsubscribe();
-        });
-        /* End Hooks */
+  module ComponentThatUpdatesStateAndRendersChildren = (
+    val component((render, ~children, ~event: Event.t(int), ()) =>
+          render(
+            () => {
+              /* Hooks */
+              let (s, setS) = useState(2);
 
-        <aComponent testVal=s> ...children </aComponent>;
-    }, ~children);
-  }));
+              useEffect(() => {
+                let unsubscribe = Event.subscribe(event, v => setS(v));
+                () => unsubscribe();
+              });
+              /* End Hooks */
+
+              <aComponent testVal=s> ...children </aComponent>;
+            },
+            ~children,
+          )
+        )
+  );
 
   test("nested state works as expected", () => {
     let rootNode = createRootNode();
@@ -197,29 +210,29 @@ test("useState", () => {
     validateStructure(rootNode, expectedStructure);
   });
 
+  module ComponentThatWrapsEitherPrimitiveOrComponent = (
+    val component((render, ~children, ~event: Event.t(renderOption), ()) =>
+          render(
+            () => {
+              /* Hooks */
+              let (s, setS) = useState(RenderAComponentWithState);
 
-module ComponentThatWrapsEitherPrimitiveOrComponent = (val component(
-    (render, ~children, ~event: Event.t(renderOption), ()) => {
-        render(() => {
-            
-            /* Hooks */
-            let (s, setS) = useState(RenderAComponentWithState);
+              useEffect(() => {
+                let unsubscribe = Event.subscribe(event, v => setS(v));
+                () => unsubscribe();
+              });
+              /* End Hook */
 
-            useEffect(() => {
-              let unsubscribe = Event.subscribe(event, v => setS(v));
-              () => unsubscribe();
-            });
-            /* End Hook */
-
-            switch (s) {
-            /* | Nothing => () */
-            | RenderAComponentWithState => <ComponentWithState />
-            | RenderAComponent(x) => <aComponent testVal=x />
-            };
-        },
-        ~children);
-    })
-);
+              switch (s) {
+              /* | Nothing => () */
+              | RenderAComponentWithState => <ComponentWithState />
+              | RenderAComponent(x) => <aComponent testVal=x />
+              };
+            },
+            ~children,
+          )
+        )
+  );
 
   test("switching between a component to a primitive and back works", () => {
     let rootNode = createRootNode();

--- a/test/PrimitiveComponentTest.re
+++ b/test/PrimitiveComponentTest.re
@@ -12,16 +12,18 @@ let createRootNode = () => {children: ref([]), nodeId: 0, nodeType: Root};
 
 let aComponent = (~testVal, ~children, ()) =>
   primitiveComponent(A(testVal), ~children);
-let bComponent = (~children, ()) =>
-  primitiveComponent(B, ~children);
-let cComponent = (~children, ()) =>
-  primitiveComponent(C, ~children);
+let bComponent = (~children, ()) => primitiveComponent(B, ~children);
+let cComponent = (~children, ()) => primitiveComponent(C, ~children);
 
-module CustomComponent = (val component((render, ~children, ()) => {
-    render(() => {
-      <aComponent testVal=1> <bComponent /> <bComponent /> </aComponent>;
-    }, ~children);  
-}));
+module CustomComponent = (
+  val component((render, ~children, ()) =>
+        render(
+          () =>
+            <aComponent testVal=1> <bComponent /> <bComponent /> </aComponent>,
+          ~children,
+        )
+      )
+);
 
 test("PrimitiveComponent", () => {
   test("BasicRenderTest", () => {

--- a/test/PrimitiveComponentTest.re
+++ b/test/PrimitiveComponentTest.re
@@ -6,24 +6,28 @@ open TestUtility;
 
 /* Use our Reconciler to create our own instance */
 module TestReact = Reactify.Make(TestReconciler);
+open TestReact;
 let createRootNode = () => {children: ref([]), nodeId: 0, nodeType: Root};
 
 let aComponent = (~testVal, ~children, ()) =>
-  TestReact.primitiveComponent(A(testVal), ~children);
+  primitiveComponent(A(testVal), ~children);
 let bComponent = (~children, ()) =>
-  TestReact.primitiveComponent(B, ~children);
+  primitiveComponent(B, ~children);
 let cComponent = (~children, ()) =>
-  TestReact.primitiveComponent(C, ~children);
+  primitiveComponent(C, ~children);
 
-let component = () =>
-  <aComponent testVal=1> <bComponent /> <bComponent /> </aComponent>;
+module CustomComponent = (val component((render, ~children, ()) => {
+    render(() => {
+      <aComponent testVal=1> <bComponent /> <bComponent /> </aComponent>;
+    }, ~children);  
+}));
 
 test("PrimitiveComponent", () => {
   test("BasicRenderTest", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
-    TestReact.updateContainer(container, <bComponent />);
+    updateContainer(container, <bComponent />);
 
     let expectedStructure = TreeNode(Root, [TreeLeaf(B)]);
     validateStructure(rootNode, expectedStructure);
@@ -31,10 +35,10 @@ test("PrimitiveComponent", () => {
 
   test("BasicRenderTest - multiple updates", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
-    TestReact.updateContainer(container, <bComponent />);
-    TestReact.updateContainer(container, <bComponent />);
+    updateContainer(container, <bComponent />);
+    updateContainer(container, <bComponent />);
 
     let expectedStructure = TreeNode(Root, [TreeLeaf(B)]);
     validateStructure(rootNode, expectedStructure);
@@ -42,15 +46,15 @@ test("PrimitiveComponent", () => {
 
   test("UpdateNodeTest", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
-    TestReact.updateContainer(container, <aComponent testVal=1 />);
+    updateContainer(container, <aComponent testVal=1 />);
 
     let expectedStructure = TreeNode(Root, [TreeLeaf(A(1))]);
     validateStructure(rootNode, expectedStructure);
 
     /* Now, we'll update the tree */
-    TestReact.updateContainer(container, <aComponent testVal=2 />);
+    updateContainer(container, <aComponent testVal=2 />);
 
     let expectedStructure = TreeNode(Root, [TreeLeaf(A(2))]);
     validateStructure(rootNode, expectedStructure);
@@ -58,9 +62,9 @@ test("PrimitiveComponent", () => {
 
   test("UpdateChildNodeTest", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
-    TestReact.updateContainer(
+    updateContainer(
       container,
       <aComponent testVal=1> <aComponent testVal=2 /> </aComponent>,
     );
@@ -70,7 +74,7 @@ test("PrimitiveComponent", () => {
     validateStructure(rootNode, expectedStructure);
 
     /* Now, we'll update the tree */
-    TestReact.updateContainer(
+    updateContainer(
       container,
       <aComponent testVal=1> <aComponent testVal=3 /> </aComponent>,
     );
@@ -82,9 +86,9 @@ test("PrimitiveComponent", () => {
 
   test("ReplaceChildNodeTest", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
-    TestReact.updateContainer(
+    updateContainer(
       container,
       <aComponent testVal=1> <aComponent testVal=2 /> </aComponent>,
     );
@@ -94,13 +98,12 @@ test("PrimitiveComponent", () => {
     validateStructure(rootNode, expectedStructure);
 
     /* Now, we'll update the tree */
-    print_endline("going for the update....");
-    TestReact.updateContainer(
+    updateContainer(
       container,
       <aComponent testVal=1> <bComponent /> </aComponent>,
     );
 
-    TestReconciler.show(rootNode);
+    show(rootNode);
     let expectedStructure =
       TreeNode(Root, [TreeNode(A(1), [TreeLeaf(B)])]);
     validateStructure(rootNode, expectedStructure);
@@ -108,9 +111,9 @@ test("PrimitiveComponent", () => {
 
   test("ReplaceChildrenWithLessChildrenTest", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
-    TestReact.updateContainer(
+    updateContainer(
       container,
       <aComponent testVal=1>
         <bComponent />
@@ -128,7 +131,7 @@ test("PrimitiveComponent", () => {
 
     /* Now, we'll update the tree */
     print_endline("going for the update....");
-    TestReact.updateContainer(
+    updateContainer(
       container,
       <aComponent testVal=1> <bComponent /> </aComponent>,
     );
@@ -140,15 +143,15 @@ test("PrimitiveComponent", () => {
 
   test("ReplaceNodeTest", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
-    TestReact.updateContainer(container, <aComponent testVal=1 />);
+    updateContainer(container, <aComponent testVal=1 />);
 
     let expectedStructure = TreeNode(Root, [TreeLeaf(A(1))]);
     validateStructure(rootNode, expectedStructure);
 
     /* Now, we'll update the tree */
-    TestReact.updateContainer(container, <bComponent />);
+    updateContainer(container, <bComponent />);
 
     let expectedStructure = TreeNode(Root, [TreeLeaf(B)]);
     validateStructure(rootNode, expectedStructure);
@@ -156,23 +159,23 @@ test("PrimitiveComponent", () => {
 
   test("RenderingChildrenTest", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeNode(A(1), [TreeLeaf(B), TreeLeaf(B)])]);
 
-    TestReact.updateContainer(container, component());
+    updateContainer(container, <CustomComponent />);
 
     validateStructure(rootNode, expectedStructure);
   });
 
   test("Regression Test - update, revert does not re-render node", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
-    TestReact.updateContainer(container, <aComponent testVal=0 />);
-    TestReact.updateContainer(container, <aComponent testVal=1 />);
-    TestReact.updateContainer(container, <aComponent testVal=0 />);
+    updateContainer(container, <aComponent testVal=0 />);
+    updateContainer(container, <aComponent testVal=1 />);
+    updateContainer(container, <aComponent testVal=0 />);
 
     let expectedStructure = TreeNode(Root, [TreeLeaf(A(0))]);
     validateStructure(rootNode, expectedStructure);

--- a/test/PrimitiveComponentTest.re
+++ b/test/PrimitiveComponentTest.re
@@ -7,6 +7,7 @@ open TestUtility;
 /* Use our Reconciler to create our own instance */
 module TestReact = Reactify.Make(TestReconciler);
 open TestReact;
+
 let createRootNode = () => {children: ref([]), nodeId: 0, nodeType: Root};
 
 let aComponent = (~testVal, ~children, ()) =>

--- a/test/StatelessComponentTest.re
+++ b/test/StatelessComponentTest.re
@@ -6,6 +6,7 @@ open Rejest;
 
 /* Use our Reconciler to create our own instance */
 module TestReact = Reactify.Make(TestReconciler);
+open TestReact;
 
 let createRootNode = () => {children: ref([]), nodeId: 0, nodeType: Root};
 
@@ -19,9 +20,10 @@ let cComponent = (~children, ()) =>
 let componentWrappingB = (~children, ()) =>
   TestReact.component(() => <bComponent />, ~children);
 
-module ComponentWrappingB = (val TestReact.component2((render, ~children, ()) => {
-    print_endline(render);
-    TestReact.component(() => <bComponent />, ~children);
+module ComponentWrappingB = (val component2((render, ~x, ~children, ()) => {
+    render(() => {
+        <aComponent testVal=x/>
+    }, ~children);
 }));
 
 test("StatelessComponentTest", () => {
@@ -32,7 +34,7 @@ test("StatelessComponentTest", () => {
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(B)]);
 
-    TestReact.updateContainer(container, <ComponentWrappingB />);
+    TestReact.updateContainer(container, <ComponentWrappingB x=5/>);
 
     validateStructure(rootNode, expectedStructure);
   });

--- a/test/StatelessComponentTest.re
+++ b/test/StatelessComponentTest.re
@@ -11,142 +11,137 @@ open TestReact;
 let createRootNode = () => {children: ref([]), nodeId: 0, nodeType: Root};
 
 let aComponent = (~testVal, ~children, ()) =>
-  TestReact.primitiveComponent(A(testVal), ~children);
+  primitiveComponent(A(testVal), ~children);
 let bComponent = (~children, ()) =>
-  TestReact.primitiveComponent(B, ~children);
+  primitiveComponent(B, ~children);
 let cComponent = (~children, ()) =>
-  TestReact.primitiveComponent(C, ~children);
+  primitiveComponent(C, ~children);
 
-let componentWrappingB = (~children, ()) =>
-  TestReact.component(() => <bComponent />, 
-  ~uniqueId="componentWrappingB",
-  ~children);
-
-module ComponentWrappingB = (val component2((render, ~x, ~children, ()) => {
-    render(() => {
-        <aComponent testVal=x/>
-    }, ~children);
-}));
+module ComponentWrappingB = 
+    (val component((render, ~children, ()) => {
+        render(() => {
+            <bComponent />
+        }, ~children);
+    }));
 
 test("StatelessComponentTest", () => {
   test("Rendering simple wrapped component", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(B)]);
 
-    TestReact.updateContainer(container, <ComponentWrappingB x=5/>);
+    updateContainer(container, <ComponentWrappingB/>);
 
     validateStructure(rootNode, expectedStructure);
   });
 
-  let componentWrappingAWithProps = (~children, ~v, ()) =>
-    TestReact.component(() => <aComponent testVal=v />, ~uniqueId="componentWrappingAWithProps", ~children);
+  module ComponentWrappingAWithProps =
+      (val component((render, ~children, ~v, ()) => {
+        render(() => {<aComponent testVal=v />}, ~children); 
+      }));
 
   test("Rendering wrapped component with prop", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(7))]);
 
-    TestReact.updateContainer(container, <componentWrappingAWithProps v=7 />);
+    updateContainer(container, <ComponentWrappingAWithProps v=7 />);
 
     validateStructure(rootNode, expectedStructure);
   });
 
   test("Rendering wrapped component multiple times with prop", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(7))]);
 
-    TestReact.updateContainer(container, <componentWrappingAWithProps v=7 />);
+    updateContainer(container, <ComponentWrappingAWithProps v=7 />);
     validateStructure(rootNode, expectedStructure);
 
-    TestReact.updateContainer(container, <componentWrappingAWithProps v=7 />);
+    updateContainer(container, <ComponentWrappingAWithProps v=7 />);
     validateStructure(rootNode, expectedStructure);
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(8))]);
 
-    TestReact.updateContainer(container, <componentWrappingAWithProps v=8 />);
+    updateContainer(container, <ComponentWrappingAWithProps v=8 />);
     validateStructure(rootNode, expectedStructure);
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(9))]);
 
-    TestReact.updateContainer(container, <componentWrappingAWithProps v=9 />);
+    updateContainer(container, <ComponentWrappingAWithProps v=9 />);
     validateStructure(rootNode, expectedStructure);
   });
 
   test("Replace primitive component to wrapped component", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(B)]);
 
-    TestReact.updateContainer(container, <bComponent />);
+    updateContainer(container, <bComponent />);
     validateStructure(rootNode, expectedStructure);
 
-    TestReact.updateContainer(container, <componentWrappingB />);
+    updateContainer(container, <ComponentWrappingB />);
     validateStructure(rootNode, expectedStructure);
   });
 
   test("Replace wrapped component with primitive component", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(B)]);
 
-    TestReact.updateContainer(container, <componentWrappingB />);
+    updateContainer(container, <ComponentWrappingB />);
     validateStructure(rootNode, expectedStructure);
 
-    TestReact.updateContainer(container, <bComponent />);
+    updateContainer(container, <bComponent />);
     validateStructure(rootNode, expectedStructure);
   });
 
-  let componentWithWrappedComponents = (~children, ()) =>
-    TestReact.component(
-      () => <aComponent testVal=1> <componentWrappingB /> </aComponent>,
-      ~uniqueId="componentWithWrappedComponents",
-      ~children,
-    );
+  module ComponentWithWrappedComponents = (val component((render, ~children, ()) => {
+    render(() => {
+        <aComponent testVal=1><ComponentWrappingB /></aComponent>
+    }, ~children);
+  }));
 
   test("Rendering wrapped component with wrappedComponent as child prop", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeNode(A(1), [TreeLeaf(B)])]);
 
-    TestReact.updateContainer(container, <componentWithWrappedComponents />);
+    updateContainer(container, <ComponentWithWrappedComponents />);
 
     validateStructure(rootNode, expectedStructure);
   });
 
-  let componentThatRendersChildren = (~children, ()) =>
-    TestReact.component(~uniqueId="componentThatRendersChildren",
-      () => <aComponent testVal=1> ...children </aComponent>,
-      ~children,
-    );
+  module ComponentThatRendersChildren = (val component((render, ~children, ()) => {
+    render(() => <aComponent testVal=1>...children</aComponent>, ~children); 
+  }));
 
   test("Rendering component that renders primitive child", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeNode(A(1), [TreeLeaf(B)])]);
 
-    TestReact.updateContainer(
+    updateContainer(
       container,
-      <componentThatRendersChildren>
+      <ComponentThatRendersChildren>
         <bComponent />
-      </componentThatRendersChildren>,
+      </ComponentThatRendersChildren>,
     );
 
     validateStructure(rootNode, expectedStructure);
@@ -154,47 +149,45 @@ test("StatelessComponentTest", () => {
 
   test("Rendering component that renders component child", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeNode(A(1), [TreeLeaf(B)])]);
 
-    TestReact.updateContainer(
+    updateContainer(
       container,
-      <componentThatRendersChildren>
-        <componentWrappingB />
-      </componentThatRendersChildren>,
+      <ComponentThatRendersChildren>
+        <ComponentWrappingB />
+      </ComponentThatRendersChildren>,
     );
 
     validateStructure(rootNode, expectedStructure);
   });
 
-  let componentWithVisibilityToggle = (~children, ~visible=true, ()) =>
-    TestReact.component(~uniqueId="componentWithVisibilityToggle", () =>
-      visible ?
-        <aComponent testVal=1> ...children </aComponent> : TestReact.empty
-    );
+  module ComponentWithVisibilityToggle = (val component((render, ~visible=true, ~children, ()) => {
+    render(() => visible ? <aComponent testVal=1>...children</aComponent> : TestReact.empty); 
+  }));
 
   test("Test toggling visibility", () => {
     let rootNode = createRootNode();
-    let container = TestReact.createContainer(rootNode);
+    let container = createContainer(rootNode);
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeNode(A(1), [TreeLeaf(B)])]);
 
-    TestReact.updateContainer(
+    updateContainer(
       container,
-      <componentWithVisibilityToggle visible=true>
-        <componentWrappingB />
-      </componentWithVisibilityToggle>,
+      <ComponentWithVisibilityToggle visible=true>
+        <ComponentWrappingB />
+      </ComponentWithVisibilityToggle>,
     );
     validateStructure(rootNode, expectedStructure);
 
-    TestReact.updateContainer(
+    updateContainer(
       container,
-      <componentWithVisibilityToggle visible=false>
-        <componentWrappingB />
-      </componentWithVisibilityToggle>,
+      <ComponentWithVisibilityToggle visible=false>
+        <ComponentWrappingB />
+      </ComponentWithVisibilityToggle>,
     );
     let expectedStructure: tree(primitives) = TreeLeaf(Root);
     validateStructure(rootNode, expectedStructure);

--- a/test/StatelessComponentTest.re
+++ b/test/StatelessComponentTest.re
@@ -12,17 +12,14 @@ let createRootNode = () => {children: ref([]), nodeId: 0, nodeType: Root};
 
 let aComponent = (~testVal, ~children, ()) =>
   primitiveComponent(A(testVal), ~children);
-let bComponent = (~children, ()) =>
-  primitiveComponent(B, ~children);
-let cComponent = (~children, ()) =>
-  primitiveComponent(C, ~children);
+let bComponent = (~children, ()) => primitiveComponent(B, ~children);
+let cComponent = (~children, ()) => primitiveComponent(C, ~children);
 
-module ComponentWrappingB = 
-    (val component((render, ~children, ()) => {
-        render(() => {
-            <bComponent />
-        }, ~children);
-    }));
+module ComponentWrappingB = (
+  val component((render, ~children, ()) =>
+        render(() => <bComponent />, ~children)
+      )
+);
 
 test("StatelessComponentTest", () => {
   test("Rendering simple wrapped component", () => {
@@ -32,15 +29,16 @@ test("StatelessComponentTest", () => {
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(B)]);
 
-    updateContainer(container, <ComponentWrappingB/>);
+    updateContainer(container, <ComponentWrappingB />);
 
     validateStructure(rootNode, expectedStructure);
   });
 
-  module ComponentWrappingAWithProps =
-      (val component((render, ~children, ~v, ()) => {
-        render(() => {<aComponent testVal=v />}, ~children); 
-      }));
+  module ComponentWrappingAWithProps = (
+    val component((render, ~children, ~v, ()) =>
+          render(() => <aComponent testVal=v />, ~children)
+        )
+  );
 
   test("Rendering wrapped component with prop", () => {
     let rootNode = createRootNode();
@@ -108,11 +106,14 @@ test("StatelessComponentTest", () => {
     validateStructure(rootNode, expectedStructure);
   });
 
-  module ComponentWithWrappedComponents = (val component((render, ~children, ()) => {
-    render(() => {
-        <aComponent testVal=1><ComponentWrappingB /></aComponent>
-    }, ~children);
-  }));
+  module ComponentWithWrappedComponents = (
+    val component((render, ~children, ()) =>
+          render(
+            () => <aComponent testVal=1> <ComponentWrappingB /> </aComponent>,
+            ~children,
+          )
+        )
+  );
 
   test("Rendering wrapped component with wrappedComponent as child prop", () => {
     let rootNode = createRootNode();
@@ -126,9 +127,14 @@ test("StatelessComponentTest", () => {
     validateStructure(rootNode, expectedStructure);
   });
 
-  module ComponentThatRendersChildren = (val component((render, ~children, ()) => {
-    render(() => <aComponent testVal=1>...children</aComponent>, ~children); 
-  }));
+  module ComponentThatRendersChildren = (
+    val component((render, ~children, ()) =>
+          render(
+            () => <aComponent testVal=1> ...children </aComponent>,
+            ~children,
+          )
+        )
+  );
 
   test("Rendering component that renders primitive child", () => {
     let rootNode = createRootNode();
@@ -164,9 +170,15 @@ test("StatelessComponentTest", () => {
     validateStructure(rootNode, expectedStructure);
   });
 
-  module ComponentWithVisibilityToggle = (val component((render, ~visible=true, ~children, ()) => {
-    render(() => visible ? <aComponent testVal=1>...children</aComponent> : TestReact.empty); 
-  }));
+  module ComponentWithVisibilityToggle = (
+    val component((render, ~visible=true, ~children, ()) =>
+          render(() =>
+            visible ?
+              <aComponent testVal=1> ...children </aComponent> :
+              TestReact.empty
+          )
+        )
+  );
 
   test("Test toggling visibility", () => {
     let rootNode = createRootNode();

--- a/test/StatelessComponentTest.re
+++ b/test/StatelessComponentTest.re
@@ -19,6 +19,10 @@ let cComponent = (~children, ()) =>
 let componentWrappingB = (~children, ()) =>
   TestReact.component(() => <bComponent />, ~children);
 
+module ComponentWrappingB = (val TestReact.component2((~children, ()) => {
+    TestReact.component(() => <bComponent />, ~children);
+}));
+
 test("StatelessComponentTest", () => {
   test("Rendering simple wrapped component", () => {
     let rootNode = createRootNode();
@@ -27,7 +31,7 @@ test("StatelessComponentTest", () => {
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(B)]);
 
-    TestReact.updateContainer(container, <componentWrappingB />);
+    TestReact.updateContainer(container, <ComponentWrappingB />);
 
     validateStructure(rootNode, expectedStructure);
   });

--- a/test/StatelessComponentTest.re
+++ b/test/StatelessComponentTest.re
@@ -19,7 +19,8 @@ let cComponent = (~children, ()) =>
 let componentWrappingB = (~children, ()) =>
   TestReact.component(() => <bComponent />, ~children);
 
-module ComponentWrappingB = (val TestReact.component2((~children, ()) => {
+module ComponentWrappingB = (val TestReact.component2((render, ~children, ()) => {
+    print_endline(render);
     TestReact.component(() => <bComponent />, ~children);
 }));
 

--- a/test/TestReconciler.re
+++ b/test/TestReconciler.re
@@ -22,13 +22,13 @@ type updateType =
 let updates: ref(list(updateType)) = ref([]);
 
 let printUpdate = _u => ();
-  /* switch (u) { */
-  /* | Append => print_endline("- append") */
-  /* | Create => print_endline("- create") */
-  /* | Remove => print_endline("- remove") */
-  /* | Update => print_endline("- update") */
-  /* | Replace => print_endline("- replace") */
-  /* }; */
+/* switch (u) { */
+/* | Append => print_endline("- append") */
+/* | Create => print_endline("- create") */
+/* | Remove => print_endline("- remove") */
+/* | Update => print_endline("- update") */
+/* | Replace => print_endline("- replace") */
+/* }; */
 
 let _currentId = ref(1);
 
@@ -105,7 +105,7 @@ let updateInstance = (node, oldPrim, newPrim) => {
     /* print_endline( */
     /*   "Updating A to: " ++ string_of_int(n) ++ " from: " ++ string_of_int(o), */
     /* ); */
-    node.nodeType = A(n);
+    node.nodeType = A(n)
   | _ => print_endline("Unhandled primitive in updateInstance")
   };
   ();

--- a/test/TestReconciler.re
+++ b/test/TestReconciler.re
@@ -65,11 +65,11 @@ let pushUpdate = u => {
 let createInstance = prim => {
   _currentId := _currentId^ + 1;
 
-  switch (prim) {
-  | A(_) => print_endline("create instance called: A")
-  | B => print_endline("create instance called: B")
-  | _ => print_endline("create instance called")
-  };
+  /* switch (prim) { */
+  /* | A(_) => print_endline("create instance called: A") */
+  /* | B => print_endline("create instance called: B") */
+  /* | _ => print_endline("create instance called") */
+  /* }; */
 
   let ret: node = {children: ref([]), nodeType: prim, nodeId: _currentId^};
 
@@ -79,10 +79,10 @@ let createInstance = prim => {
 
 let appendChild = (parent, child) => {
   parent.children := parent.children^ @ [child];
-  print_endline(
-    "append child - new count: "
-    ++ string_of_int(List.length(parent.children^)),
-  );
+  /* print_endline( */
+  /*   "append child - new count: " */
+  /*   ++ string_of_int(List.length(parent.children^)), */
+  /* ); */
   pushUpdate(Append);
 };
 
@@ -101,10 +101,10 @@ let removeChild = (parent, child) => {
 
 let updateInstance = (node, oldPrim, newPrim) => {
   switch (oldPrim, newPrim) {
-  | (A(o), A(n)) =>
-    print_endline(
-      "Updating A to: " ++ string_of_int(n) ++ " from: " ++ string_of_int(o),
-    );
+  | (A(_o), A(n)) =>
+    /* print_endline( */
+    /*   "Updating A to: " ++ string_of_int(n) ++ " from: " ++ string_of_int(o), */
+    /* ); */
     node.nodeType = A(n);
   | _ => print_endline("Unhandled primitive in updateInstance")
   };
@@ -120,37 +120,3 @@ let replaceChild = (parent, newChild, oldChild) => {
   appendChild(parent, newChild);
   pushUpdate(Replace);
 };
-
-let a11 = A(1);
-let a12 = A(1);
-let a2 = A(2);
-
-/* let d11 = D({testVal: 1}); */
-/* let d12 = D({testVal: 1}); */
-/* let d2 = D({testVal: 2}); */
-
-let equal_constructors = (x: 'a, y: 'a) => {
-  let r = Obj.repr(x)
-  and s = Obj.repr(y);
-  if (Obj.is_int(r) && Obj.is_int(s)) {
-    (Obj.obj(r): int) == (Obj.obj(s): int);
-  } else if (Obj.is_block(r) && Obj.is_block(s)) {
-    Obj.tag(r) == Obj.tag(s);
-  } else {
-    false;
-  };
-};
-
-print_endline("a11 == a12? " ++ string_of_bool(a11 == a12));
-print_endline("a12 == a2?" ++ string_of_bool(a2 == a11));
-print_endline(
-  "equal constructors a11 & a2?"
-  ++ string_of_bool(equal_constructors(a11, a2)),
-);
-print_endline(
-  "equal constructors b & c?" ++ string_of_bool(equal_constructors(B, C)),
-);
-
-/* print_endline ("d11 == d12? " ++ string_of_bool(d11 == d12)); */
-/* print_endline ("d12 == d2?" ++ string_of_bool(d2 == d11)); */
-/* print_endline ("equal constructors d & d?" ++ string_of_bool(equal_constructors(d11, d2))); */

--- a/test/TestReconciler.re
+++ b/test/TestReconciler.re
@@ -21,14 +21,14 @@ type updateType =
 
 let updates: ref(list(updateType)) = ref([]);
 
-let printUpdate = u =>
-  switch (u) {
-  | Append => print_endline("- append")
-  | Create => print_endline("- create")
-  | Remove => print_endline("- remove")
-  | Update => print_endline("- update")
-  | Replace => print_endline("- replace")
-  };
+let printUpdate = _u => ();
+  /* switch (u) { */
+  /* | Append => print_endline("- append") */
+  /* | Create => print_endline("- create") */
+  /* | Remove => print_endline("- remove") */
+  /* | Update => print_endline("- update") */
+  /* | Replace => print_endline("- replace") */
+  /* }; */
 
 let _currentId = ref(1);
 
@@ -87,15 +87,15 @@ let appendChild = (parent, child) => {
 };
 
 let removeChild = (parent, child) => {
-  let prevCount = List.length(parent.children^);
+  /* let prevCount = List.length(parent.children^); */
   parent.children := List.filter(c => c != child, parent.children^);
-  let newCount = List.length(parent.children^);
-  print_endline(
-    "remove child - previous count: "
-    ++ string_of_int(prevCount)
-    ++ " new count: "
-    ++ string_of_int(newCount),
-  );
+  /* let newCount = List.length(parent.children^); */
+  /* print_endline( */
+  /*   "remove child - previous count: " */
+  /*   ++ string_of_int(prevCount) */
+  /*   ++ " new count: " */
+  /*   ++ string_of_int(newCount), */
+  /* ); */
   pushUpdate(Remove);
 };
 

--- a/test/UtilityTest.re
+++ b/test/UtilityTest.re
@@ -50,11 +50,10 @@ test("Utility", () => {
     let a = () => ();
     /* let b = () => (); */
 
-    let fn = (f) => f;
+    let fn = f => f;
 
     let a0 = fn(a);
     let a1 = fn(a);
-
 
     expect(a0 === a1).toBe(true);
   });


### PR DESCRIPTION
__Issue:__ Currently, we have no way to distinguish whether a component came from the same 'component class' today. This is important when determining whether to reuse state/effects. #26 went a step forward but the API is a bit clunky:
```
let componentWrappingB = (~children, ~x, ()) =>
  TestReact.component(() => <bComponent />, 
  ~uniqueId="componentWrappingB",
  ~children);
```

I'm proposing moving to a new API for creating components, using [first-class modules](https://v1.realworldocaml.org/v1/en/html/first-class-modules.html) - a function that returns a module.

This allows us to do the following:
- Implicitly create a unique class id, instead of leaving that burden on the user
- Implement custom components in an 'uppercase' convention, which seems to be a dominant style in the React ecosystem.

The new syntax would be:
module ComponentWrappingB = 
    (val component((render, ~x, ~children, ()) => 
        render(() => {
            <aComponent testVal=x/>
        }, ~children);
));

The `component` function creates the module (`val` unpacks it), and there would be a render function passed to the component.

And could be used as `<ComponentWrappingB x />`.

The anatomy of the function would be:
```
module ComponentWrappingB = 
    (val component((render, /* ...props */, ~children, ()) => 
        render(() => {
            /* ...any hooks here... */

            /* ...return another custom component / primitive component */
            <aComponent testVal=x/>
        }, ~children);
));
```

I think this is a step in a better direction, but I'd be interested to see if there is a way we could scrap that `render` function. A potential point of confusion I could see is perhaps users putting hooks outside the `render` block - we should make sure that throws.

