### PR TITLE
Add _esy/ to .gitignore, track esy.lock folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ typings/
 .next
 
 _build/
+_esy/
 
 *.install
 

--- a/esy.lock/.gitattributes
+++ b/esy.lock/.gitattributes
@@ -1,0 +1,3 @@
+
+# Set eol to LF so files aren't converted to CRLF-eol on Windows.
+* text eol=lf

--- a/esy.lock/.gitignore
+++ b/esy.lock/.gitignore
@@ -1,0 +1,3 @@
+
+# Reset any possible .gitignore, we want all esy.lock to be un-ignored.
+!*

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,0 +1,979 @@
+{
+  "checksum": "6ccb4a0b2f1e5e4a976c3a2d50e91e3c",
+  "root": "reason-reactify@link:./package.json",
+  "node": {
+    "rejest@1.2.0": {
+      "id": "rejest@1.2.0",
+      "name": "rejest",
+      "version": "1.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/rejest/-/rejest-1.2.0.tgz#sha1:bfa2fe9de6d8ab7da36cf1a14fd56589be5b1f49"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "refmterr@3.1.10", "ocaml@4.6.9",
+        "@opam/lwt_ppx@opam:1.2.1@3664325b", "@opam/lwt@opam:4.1.0@114c53b7",
+        "@opam/lambda-term@opam:1.13@73165687",
+        "@opam/js_of_ocaml-lwt@opam:3.2.1@e959d698",
+        "@opam/js_of_ocaml-compiler@opam:3.2.1@8e97c5e5",
+        "@opam/js_of_ocaml@opam:3.2.0@0926e4fb",
+        "@opam/dune@opam:1.6.0@3042a2f0", "@opam/chalk@opam:1.0@54507e3f",
+        "@esy-ocaml/reason@3.3.7"
+      ],
+      "devDependencies": []
+    },
+    "refmterr@3.1.10": {
+      "id": "refmterr@3.1.10",
+      "name": "refmterr",
+      "version": "3.1.10",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/refmterr/-/refmterr-3.1.10.tgz#sha1:7c3e238022acb5de4e2254ab506d70eee13c0a46"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/re@opam:1.8.0@b017e421",
+        "@opam/dune@opam:1.6.0@3042a2f0", "@esy-ocaml/reason@3.3.7"
+      ],
+      "devDependencies": []
+    },
+    "reason-reactify@link:./package.json": {
+      "id": "reason-reactify@link:./package.json",
+      "name": "reason-reactify",
+      "version": "link:./package.json",
+      "source": { "type": "link", "path": ".", "manifest": "package.json" },
+      "overrides": [],
+      "dependencies": [
+        "rejest@1.2.0", "refmterr@3.1.10", "ocaml@4.6.9",
+        "@opam/lwt@opam:4.1.0@114c53b7",
+        "@opam/lambda-term@opam:1.13@73165687",
+        "@opam/js_of_ocaml-compiler@opam:3.2.1@8e97c5e5",
+        "@opam/dune@opam:1.6.0@3042a2f0", "@esy-ocaml/reason@3.3.7"
+      ],
+      "devDependencies": [ "@esy-ocaml/merlin@3.0.5005" ]
+    },
+    "ocaml@4.6.9": {
+      "id": "ocaml@4.6.9",
+      "name": "ocaml",
+      "version": "4.6.9",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/ocaml/-/ocaml-4.6.9.tgz#sha1:4561135b32f59a5bafa8e91019a58515508d6e4c"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "@opam/zed@opam:1.6@e28f8115": {
+      "id": "@opam/zed@opam:1.6@e28f8115",
+      "name": "@opam/zed",
+      "version": "opam:1.6",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/f7/f75c3094af1a22f9801d5ca5eb2d40e0#md5:f75c3094af1a22f9801d5ca5eb2d40e0",
+          "archive:https://github.com/diml/zed/releases/download/1.6/zed-1.6.tbz#md5:f75c3094af1a22f9801d5ca5eb2d40e0"
+        ],
+        "opam": {
+          "name": "zed",
+          "version": "1.6",
+          "path": "esy.lock/opam/zed.1.6"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/react@opam:1.2.1@dddc105c",
+        "@opam/jbuilder@opam:transition@8c8ec590",
+        "@opam/camomile@opam:1.0.1@d46bbcb6",
+        "@opam/base-bytes@opam:base@75bd4047", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/yojson@opam:1.4.1@008b9b27": {
+      "id": "@opam/yojson@opam:1.4.1@008b9b27",
+      "name": "@opam/yojson",
+      "version": "opam:1.4.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/3e/3ea6e36422dd670e8ab880710d5f7398#md5:3ea6e36422dd670e8ab880710d5f7398",
+          "archive:https://github.com/mjambon/yojson/archive/v1.4.1.tar.gz#md5:3ea6e36422dd670e8ab880710d5f7398"
+        ],
+        "opam": {
+          "name": "yojson",
+          "version": "1.4.1",
+          "path": "esy.lock/opam/yojson.1.4.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/jbuilder@opam:transition@8c8ec590",
+        "@opam/easy-format@opam:1.3.1@85a6474a",
+        "@opam/cppo@opam:1.6.5@b397a057", "@opam/biniou@opam:1.2.0@4e4a426f",
+        "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/uchar@opam:0.0.2@12f53e47": {
+      "id": "@opam/uchar@opam:0.0.2@12f53e47",
+      "name": "@opam/uchar",
+      "version": "opam:0.0.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/c9/c9ba2c738d264c420c642f7bb1cf4a36#md5:c9ba2c738d264c420c642f7bb1cf4a36",
+          "archive:https://github.com/ocaml/uchar/releases/download/v0.0.2/uchar-0.0.2.tbz#md5:c9ba2c738d264c420c642f7bb1cf4a36"
+        ],
+        "opam": {
+          "name": "uchar",
+          "version": "0.0.2",
+          "path": "esy.lock/opam/uchar.0.0.2"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/ocamlbuild@opam:0.12.0@bbe76db8",
+        "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/topkg@opam:1.0.0@e7eb4139": {
+      "id": "@opam/topkg@opam:1.0.0@e7eb4139",
+      "name": "@opam/topkg",
+      "version": "opam:1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/e3/e3d76bda06bf68cb5853caf6627da603#md5:e3d76bda06bf68cb5853caf6627da603",
+          "archive:http://erratique.ch/software/topkg/releases/topkg-1.0.0.tbz#md5:e3d76bda06bf68cb5853caf6627da603"
+        ],
+        "opam": {
+          "name": "topkg",
+          "version": "1.0.0",
+          "path": "esy.lock/opam/topkg.1.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/result@opam:1.3@7af06772",
+        "@opam/ocamlfind@opam:1.8.0@6fa9aaf5",
+        "@opam/ocamlbuild@opam:0.12.0@bbe76db8", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/seq@opam:0.1@dbeb6f4c": {
+      "id": "@opam/seq@opam:0.1@dbeb6f4c",
+      "name": "@opam/seq",
+      "version": "opam:0.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/0e/0e87f9709541ed46ecb6f414bc31458c#md5:0e87f9709541ed46ecb6f414bc31458c",
+          "archive:https://github.com/c-cube/seq/archive/0.1.tar.gz#md5:0e87f9709541ed46ecb6f414bc31458c"
+        ],
+        "opam": {
+          "name": "seq",
+          "version": "0.1",
+          "path": "esy.lock/opam/seq.0.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/ocamlfind@opam:1.8.0@6fa9aaf5",
+        "@opam/ocamlbuild@opam:0.12.0@bbe76db8", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/result@opam:1.3@7af06772": {
+      "id": "@opam/result@opam:1.3@7af06772",
+      "name": "@opam/result",
+      "version": "opam:1.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/4b/4beebefd41f7f899b6eeba7414e7ae01#md5:4beebefd41f7f899b6eeba7414e7ae01",
+          "archive:https://github.com/janestreet/result/releases/download/1.3/result-1.3.tbz#md5:4beebefd41f7f899b6eeba7414e7ae01"
+        ],
+        "opam": {
+          "name": "result",
+          "version": "1.3",
+          "path": "esy.lock/opam/result.1.3"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/jbuilder@opam:transition@8c8ec590",
+        "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/react@opam:1.2.1@dddc105c": {
+      "id": "@opam/react@opam:1.2.1@dddc105c",
+      "name": "@opam/react",
+      "version": "opam:1.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/ce/ce1454438ce4e9d2931248d3abba1fcc#md5:ce1454438ce4e9d2931248d3abba1fcc",
+          "archive:http://erratique.ch/software/react/releases/react-1.2.1.tbz#md5:ce1454438ce4e9d2931248d3abba1fcc"
+        ],
+        "opam": {
+          "name": "react",
+          "version": "1.2.1",
+          "path": "esy.lock/opam/react.1.2.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/topkg@opam:1.0.0@e7eb4139",
+        "@opam/ocamlfind@opam:1.8.0@6fa9aaf5",
+        "@opam/ocamlbuild@opam:0.12.0@bbe76db8", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/re@opam:1.8.0@b017e421": {
+      "id": "@opam/re@opam:1.8.0@b017e421",
+      "name": "@opam/re",
+      "version": "opam:1.8.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/76/765f6f8d3e6ab200866e719ed7e5178d#md5:765f6f8d3e6ab200866e719ed7e5178d",
+          "archive:https://github.com/ocaml/ocaml-re/releases/download/1.8.0/re-1.8.0.tbz#md5:765f6f8d3e6ab200866e719ed7e5178d"
+        ],
+        "opam": {
+          "name": "re",
+          "version": "1.8.0",
+          "path": "esy.lock/opam/re.1.8.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/seq@opam:0.1@dbeb6f4c",
+        "@opam/jbuilder@opam:transition@8c8ec590", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/ppx_tools_versioned@opam:5.2.1@1c27c15e": {
+      "id": "@opam/ppx_tools_versioned@opam:5.2.1@1c27c15e",
+      "name": "@opam/ppx_tools_versioned",
+      "version": "opam:5.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/1a/1ae6ae43ec161fbbf12c2b4d3a7e26f5#md5:1ae6ae43ec161fbbf12c2b4d3a7e26f5",
+          "archive:https://github.com/ocaml-ppx/ppx_tools_versioned/archive/5.2.1.tar.gz#md5:1ae6ae43ec161fbbf12c2b4d3a7e26f5"
+        ],
+        "opam": {
+          "name": "ppx_tools_versioned",
+          "version": "5.2.1",
+          "path": "esy.lock/opam/ppx_tools_versioned.5.2.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/ocaml-migrate-parsetree@opam:1.1.0@48c1552a",
+        "@opam/jbuilder@opam:transition@8c8ec590", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/ocamlfind@opam:1.8.0@6fa9aaf5": {
+      "id": "@opam/ocamlfind@opam:1.8.0@6fa9aaf5",
+      "name": "@opam/ocamlfind",
+      "version": "opam:1.8.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/a7/a710c559667672077a93d34eb6a42e5b#md5:a710c559667672077a93d34eb6a42e5b",
+          "archive:http://download2.camlcity.org/download/findlib-1.8.0.tar.gz#md5:a710c559667672077a93d34eb6a42e5b",
+          "archive:http://download.camlcity.org/download/findlib-1.8.0.tar.gz#md5:a710c559667672077a93d34eb6a42e5b"
+        ],
+        "opam": {
+          "name": "ocamlfind",
+          "version": "1.8.0",
+          "path": "esy.lock/opam/ocamlfind.1.8.0"
+        }
+      },
+      "overrides": [
+        "path:esy.lock/opam-override/ocamlfind.1.8.0/package.json"
+      ],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/conf-m4@opam:1@d4932910",
+        "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/ocamlbuild@opam:0.12.0@bbe76db8": {
+      "id": "@opam/ocamlbuild@opam:0.12.0@bbe76db8",
+      "name": "@opam/ocamlbuild",
+      "version": "opam:0.12.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/44/442baa19470bd49150f153122e22907b#md5:442baa19470bd49150f153122e22907b",
+          "archive:https://github.com/ocaml/ocamlbuild/archive/0.12.0.tar.gz#md5:442baa19470bd49150f153122e22907b"
+        ],
+        "opam": {
+          "name": "ocamlbuild",
+          "version": "0.12.0",
+          "path": "esy.lock/opam/ocamlbuild.0.12.0"
+        }
+      },
+      "overrides": [
+        "path:esy.lock/opam-override/ocamlbuild.0.12.0/package.json"
+      ],
+      "dependencies": [ "ocaml@4.6.9", "@esy-ocaml/substs@0.0.1" ],
+      "devDependencies": []
+    },
+    "@opam/ocaml-migrate-parsetree@opam:1.1.0@48c1552a": {
+      "id": "@opam/ocaml-migrate-parsetree@opam:1.1.0@48c1552a",
+      "name": "@opam/ocaml-migrate-parsetree",
+      "version": "opam:1.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/7d/7dd4808e27af98065f63604c9658d311#md5:7dd4808e27af98065f63604c9658d311",
+          "archive:https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.1.0/ocaml-migrate-parsetree-1.1.0.tbz#md5:7dd4808e27af98065f63604c9658d311"
+        ],
+        "opam": {
+          "name": "ocaml-migrate-parsetree",
+          "version": "1.1.0",
+          "path": "esy.lock/opam/ocaml-migrate-parsetree.1.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/result@opam:1.3@7af06772",
+        "@opam/dune@opam:1.6.0@3042a2f0", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/merlin-extend@opam:0.3@77408bd7": {
+      "id": "@opam/merlin-extend@opam:0.3@77408bd7",
+      "name": "@opam/merlin-extend",
+      "version": "opam:0.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/9c/9c6dfd4f53328f02f12fcc265f4e2dda#md5:9c6dfd4f53328f02f12fcc265f4e2dda",
+          "archive:https://github.com/let-def/merlin-extend/archive/v0.3.tar.gz#md5:9c6dfd4f53328f02f12fcc265f4e2dda"
+        ],
+        "opam": {
+          "name": "merlin-extend",
+          "version": "0.3",
+          "path": "esy.lock/opam/merlin-extend.0.3"
+        }
+      },
+      "overrides": [
+        "path:esy.lock/opam-override/merlin-extend.0.3/package.json"
+      ],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/ocamlfind@opam:1.8.0@6fa9aaf5",
+        "@opam/cppo@opam:1.6.5@b397a057", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/menhir@opam:20171013@8c9fcad5": {
+      "id": "@opam/menhir@opam:20171013@8c9fcad5",
+      "name": "@opam/menhir",
+      "version": "opam:20171013",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/62/620863edea40437390ee5e5bd82fba11#md5:620863edea40437390ee5e5bd82fba11",
+          "archive:http://gallium.inria.fr/~fpottier/menhir/menhir-20171013.tar.gz#md5:620863edea40437390ee5e5bd82fba11"
+        ],
+        "opam": {
+          "name": "menhir",
+          "version": "20171013",
+          "path": "esy.lock/opam/menhir.20171013"
+        }
+      },
+      "overrides": [
+        "path:esy.lock/opam-override/menhir.20171013/package.json"
+      ],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/ocamlfind@opam:1.8.0@6fa9aaf5",
+        "@opam/ocamlbuild@opam:0.12.0@bbe76db8", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/lwt_react@opam:1.1.1@5e12fc6c": {
+      "id": "@opam/lwt_react@opam:1.1.1@5e12fc6c",
+      "name": "@opam/lwt_react",
+      "version": "opam:1.1.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/3b/3bbde866884e32cc7a9d9cbd1e52bde3#md5:3bbde866884e32cc7a9d9cbd1e52bde3",
+          "archive:https://github.com/ocsigen/lwt/archive/4.0.0.tar.gz#md5:3bbde866884e32cc7a9d9cbd1e52bde3"
+        ],
+        "opam": {
+          "name": "lwt_react",
+          "version": "1.1.1",
+          "path": "esy.lock/opam/lwt_react.1.1.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/react@opam:1.2.1@dddc105c",
+        "@opam/lwt@opam:4.1.0@114c53b7",
+        "@opam/jbuilder@opam:transition@8c8ec590", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/lwt_ppx@opam:1.2.1@3664325b": {
+      "id": "@opam/lwt_ppx@opam:1.2.1@3664325b",
+      "name": "@opam/lwt_ppx",
+      "version": "opam:1.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/e9/e919bee206f18b3d49250ecf9584fde7#md5:e919bee206f18b3d49250ecf9584fde7",
+          "archive:https://github.com/ocsigen/lwt/archive/4.1.0.tar.gz#md5:e919bee206f18b3d49250ecf9584fde7"
+        ],
+        "opam": {
+          "name": "lwt_ppx",
+          "version": "1.2.1",
+          "path": "esy.lock/opam/lwt_ppx.1.2.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/ppx_tools_versioned@opam:5.2.1@1c27c15e",
+        "@opam/ocaml-migrate-parsetree@opam:1.1.0@48c1552a",
+        "@opam/lwt@opam:4.1.0@114c53b7",
+        "@opam/jbuilder@opam:transition@8c8ec590", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/lwt_log@opam:1.1.0@84b338f2": {
+      "id": "@opam/lwt_log@opam:1.1.0@84b338f2",
+      "name": "@opam/lwt_log",
+      "version": "opam:1.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/92/92142135d01a4d7e805990cc98653d55#md5:92142135d01a4d7e805990cc98653d55",
+          "archive:https://github.com/aantron/lwt_log/archive/1.1.0.tar.gz#md5:92142135d01a4d7e805990cc98653d55"
+        ],
+        "opam": {
+          "name": "lwt_log",
+          "version": "1.1.0",
+          "path": "esy.lock/opam/lwt_log.1.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/lwt@opam:4.1.0@114c53b7",
+        "@opam/jbuilder@opam:transition@8c8ec590", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/lwt@opam:4.1.0@114c53b7": {
+      "id": "@opam/lwt@opam:4.1.0@114c53b7",
+      "name": "@opam/lwt",
+      "version": "opam:4.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/e9/e919bee206f18b3d49250ecf9584fde7#md5:e919bee206f18b3d49250ecf9584fde7",
+          "archive:https://github.com/ocsigen/lwt/archive/4.1.0.tar.gz#md5:e919bee206f18b3d49250ecf9584fde7"
+        ],
+        "opam": {
+          "name": "lwt",
+          "version": "4.1.0",
+          "path": "esy.lock/opam/lwt.4.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/result@opam:1.3@7af06772",
+        "@opam/ocamlfind@opam:1.8.0@6fa9aaf5",
+        "@opam/jbuilder@opam:transition@8c8ec590",
+        "@opam/cppo@opam:1.6.5@b397a057",
+        "@opam/base-unix@opam:base@5229aaf3",
+        "@opam/base-threads@opam:base@37e6a5c8", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/lambda-term@opam:1.13@73165687": {
+      "id": "@opam/lambda-term@opam:1.13@73165687",
+      "name": "@opam/lambda-term",
+      "version": "opam:1.13",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/c1/c13826a97014d4d573b927b623c7e043#md5:c13826a97014d4d573b927b623c7e043",
+          "archive:https://github.com/diml/lambda-term/releases/download/1.13/lambda-term-1.13.tbz#md5:c13826a97014d4d573b927b623c7e043"
+        ],
+        "opam": {
+          "name": "lambda-term",
+          "version": "1.13",
+          "path": "esy.lock/opam/lambda-term.1.13"
+        }
+      },
+      "overrides": [
+        "path:esy.lock/opam-override/lambda-term.1.13/package.json"
+      ],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/zed@opam:1.6@e28f8115",
+        "@opam/react@opam:1.2.1@dddc105c",
+        "@opam/lwt_react@opam:1.1.1@5e12fc6c",
+        "@opam/lwt_log@opam:1.1.0@84b338f2", "@opam/lwt@opam:4.1.0@114c53b7",
+        "@opam/jbuilder@opam:transition@8c8ec590",
+        "@opam/camomile@opam:1.0.1@d46bbcb6", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/js_of_ocaml-ppx@opam:3.2.0@9330db31": {
+      "id": "@opam/js_of_ocaml-ppx@opam:3.2.0@9330db31",
+      "name": "@opam/js_of_ocaml-ppx",
+      "version": "opam:3.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/5f/5f7d6121f2b549b5ee83a625a142219b#md5:5f7d6121f2b549b5ee83a625a142219b",
+          "archive:https://github.com/ocsigen/js_of_ocaml/archive/3.2.0.tar.gz#md5:5f7d6121f2b549b5ee83a625a142219b"
+        ],
+        "opam": {
+          "name": "js_of_ocaml-ppx",
+          "version": "3.2.0",
+          "path": "esy.lock/opam/js_of_ocaml-ppx.3.2.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/ppx_tools_versioned@opam:5.2.1@1c27c15e",
+        "@opam/ocaml-migrate-parsetree@opam:1.1.0@48c1552a",
+        "@opam/js_of_ocaml@opam:3.2.0@0926e4fb",
+        "@opam/jbuilder@opam:transition@8c8ec590", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/js_of_ocaml-lwt@opam:3.2.1@e959d698": {
+      "id": "@opam/js_of_ocaml-lwt@opam:3.2.1@e959d698",
+      "name": "@opam/js_of_ocaml-lwt",
+      "version": "opam:3.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/5e/5ebfb1bf85dc90e45e0f7ca71a9053b4#md5:5ebfb1bf85dc90e45e0f7ca71a9053b4",
+          "archive:https://github.com/ocsigen/js_of_ocaml/archive/3.2.1.tar.gz#md5:5ebfb1bf85dc90e45e0f7ca71a9053b4"
+        ],
+        "opam": {
+          "name": "js_of_ocaml-lwt",
+          "version": "3.2.1",
+          "path": "esy.lock/opam/js_of_ocaml-lwt.3.2.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/lwt_log@opam:1.1.0@84b338f2",
+        "@opam/lwt@opam:4.1.0@114c53b7",
+        "@opam/js_of_ocaml-ppx@opam:3.2.0@9330db31",
+        "@opam/js_of_ocaml@opam:3.2.0@0926e4fb",
+        "@opam/jbuilder@opam:transition@8c8ec590", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/js_of_ocaml-compiler@opam:3.2.1@8e97c5e5": {
+      "id": "@opam/js_of_ocaml-compiler@opam:3.2.1@8e97c5e5",
+      "name": "@opam/js_of_ocaml-compiler",
+      "version": "opam:3.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/5e/5ebfb1bf85dc90e45e0f7ca71a9053b4#md5:5ebfb1bf85dc90e45e0f7ca71a9053b4",
+          "archive:https://github.com/ocsigen/js_of_ocaml/archive/3.2.1.tar.gz#md5:5ebfb1bf85dc90e45e0f7ca71a9053b4"
+        ],
+        "opam": {
+          "name": "js_of_ocaml-compiler",
+          "version": "3.2.1",
+          "path": "esy.lock/opam/js_of_ocaml-compiler.3.2.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/yojson@opam:1.4.1@008b9b27",
+        "@opam/ocamlfind@opam:1.8.0@6fa9aaf5",
+        "@opam/jbuilder@opam:transition@8c8ec590",
+        "@opam/cppo@opam:1.6.5@b397a057",
+        "@opam/cmdliner@opam:1.0.2@42bb9730", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/js_of_ocaml@opam:3.2.0@0926e4fb": {
+      "id": "@opam/js_of_ocaml@opam:3.2.0@0926e4fb",
+      "name": "@opam/js_of_ocaml",
+      "version": "opam:3.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/5f/5f7d6121f2b549b5ee83a625a142219b#md5:5f7d6121f2b549b5ee83a625a142219b",
+          "archive:https://github.com/ocsigen/js_of_ocaml/archive/3.2.0.tar.gz#md5:5f7d6121f2b549b5ee83a625a142219b"
+        ],
+        "opam": {
+          "name": "js_of_ocaml",
+          "version": "3.2.0",
+          "path": "esy.lock/opam/js_of_ocaml.3.2.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/uchar@opam:0.0.2@12f53e47",
+        "@opam/ppx_tools_versioned@opam:5.2.1@1c27c15e",
+        "@opam/ocaml-migrate-parsetree@opam:1.1.0@48c1552a",
+        "@opam/js_of_ocaml-compiler@opam:3.2.1@8e97c5e5",
+        "@opam/jbuilder@opam:transition@8c8ec590", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/jbuilder@opam:transition@8c8ec590": {
+      "id": "@opam/jbuilder@opam:transition@8c8ec590",
+      "name": "@opam/jbuilder",
+      "version": "opam:transition",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "jbuilder",
+          "version": "transition",
+          "path": "esy.lock/opam/jbuilder.transition"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/dune@opam:1.6.0@3042a2f0",
+        "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/easy-format@opam:1.3.1@85a6474a": {
+      "id": "@opam/easy-format@opam:1.3.1@85a6474a",
+      "name": "@opam/easy-format",
+      "version": "opam:1.3.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/4e/4e163700fb88fdcd6b8976c3a216c8ea#md5:4e163700fb88fdcd6b8976c3a216c8ea",
+          "archive:https://github.com/mjambon/easy-format/archive/v1.3.1.tar.gz#md5:4e163700fb88fdcd6b8976c3a216c8ea"
+        ],
+        "opam": {
+          "name": "easy-format",
+          "version": "1.3.1",
+          "path": "esy.lock/opam/easy-format.1.3.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/jbuilder@opam:transition@8c8ec590",
+        "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/dune@opam:1.6.0@3042a2f0": {
+      "id": "@opam/dune@opam:1.6.0@3042a2f0",
+      "name": "@opam/dune",
+      "version": "opam:1.6.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/ac/ac99a0ece781c84117772219f5a39007#md5:ac99a0ece781c84117772219f5a39007",
+          "archive:https://github.com/ocaml/dune/releases/download/1.6.0/dune-1.6.0.tbz#md5:ac99a0ece781c84117772219f5a39007"
+        ],
+        "opam": {
+          "name": "dune",
+          "version": "1.6.0",
+          "path": "esy.lock/opam/dune.1.6.0"
+        }
+      },
+      "overrides": [ "path:esy.lock/opam-override/dune.1.6.0/package.json" ],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/base-unix@opam:base@5229aaf3",
+        "@opam/base-threads@opam:base@37e6a5c8", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/cppo@opam:1.6.5@b397a057": {
+      "id": "@opam/cppo@opam:1.6.5@b397a057",
+      "name": "@opam/cppo",
+      "version": "opam:1.6.5",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/1c/1cd25741d31417995b0973fe0b6f6c82#md5:1cd25741d31417995b0973fe0b6f6c82",
+          "archive:https://github.com/mjambon/cppo/archive/v1.6.5.tar.gz#md5:1cd25741d31417995b0973fe0b6f6c82"
+        ],
+        "opam": {
+          "name": "cppo",
+          "version": "1.6.5",
+          "path": "esy.lock/opam/cppo.1.6.5"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/jbuilder@opam:transition@8c8ec590",
+        "@opam/base-unix@opam:base@5229aaf3", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/conf-which@opam:1@2dd0e651": {
+      "id": "@opam/conf-which@opam:1@2dd0e651",
+      "name": "@opam/conf-which",
+      "version": "opam:1",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "conf-which",
+          "version": "1",
+          "path": "esy.lock/opam/conf-which.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [ "@esy-ocaml/substs@0.0.1" ],
+      "devDependencies": []
+    },
+    "@opam/conf-m4@opam:1@d4932910": {
+      "id": "@opam/conf-m4@opam:1@d4932910",
+      "name": "@opam/conf-m4",
+      "version": "opam:1",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "conf-m4",
+          "version": "1",
+          "path": "esy.lock/opam/conf-m4.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [ "@esy-ocaml/substs@0.0.1" ],
+      "devDependencies": []
+    },
+    "@opam/cmdliner@opam:1.0.2@42bb9730": {
+      "id": "@opam/cmdliner@opam:1.0.2@42bb9730",
+      "name": "@opam/cmdliner",
+      "version": "opam:1.0.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/ab/ab2f0130e88e8dcd723ac6154c98a881#md5:ab2f0130e88e8dcd723ac6154c98a881",
+          "archive:http://erratique.ch/software/cmdliner/releases/cmdliner-1.0.2.tbz#md5:ab2f0130e88e8dcd723ac6154c98a881"
+        ],
+        "opam": {
+          "name": "cmdliner",
+          "version": "1.0.2",
+          "path": "esy.lock/opam/cmdliner.1.0.2"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/topkg@opam:1.0.0@e7eb4139",
+        "@opam/result@opam:1.3@7af06772",
+        "@opam/ocamlfind@opam:1.8.0@6fa9aaf5",
+        "@opam/ocamlbuild@opam:0.12.0@bbe76db8", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/chalk@opam:1.0@54507e3f": {
+      "id": "@opam/chalk@opam:1.0@54507e3f",
+      "name": "@opam/chalk",
+      "version": "opam:1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/c6/c685f3024e5a4e74c86b4d9ce67ae34f#md5:c685f3024e5a4e74c86b4d9ce67ae34f",
+          "archive:https://github.com/nickzuber/chalk/archive/v1.0.tar.gz#md5:c685f3024e5a4e74c86b4d9ce67ae34f"
+        ],
+        "opam": {
+          "name": "chalk",
+          "version": "1.0",
+          "path": "esy.lock/opam/chalk.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/ocamlfind@opam:1.8.0@6fa9aaf5",
+        "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/camomile@opam:1.0.1@d46bbcb6": {
+      "id": "@opam/camomile@opam:1.0.1@d46bbcb6",
+      "name": "@opam/camomile",
+      "version": "opam:1.0.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/82/82e016653431353a07f22c259adc6e05#md5:82e016653431353a07f22c259adc6e05",
+          "archive:https://github.com/yoriyuki/Camomile/releases/download/1.0.1/camomile-1.0.1.tbz#md5:82e016653431353a07f22c259adc6e05"
+        ],
+        "opam": {
+          "name": "camomile",
+          "version": "1.0.1",
+          "path": "esy.lock/opam/camomile.1.0.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/jbuilder@opam:transition@8c8ec590",
+        "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/biniou@opam:1.2.0@4e4a426f": {
+      "id": "@opam/biniou@opam:1.2.0@4e4a426f",
+      "name": "@opam/biniou",
+      "version": "opam:1.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/f3/f3e92358e832ed94eaf23ce622ccc2f9#md5:f3e92358e832ed94eaf23ce622ccc2f9",
+          "archive:https://github.com/mjambon/biniou/archive/v1.2.0.tar.gz#md5:f3e92358e832ed94eaf23ce622ccc2f9"
+        ],
+        "opam": {
+          "name": "biniou",
+          "version": "1.2.0",
+          "path": "esy.lock/opam/biniou.1.2.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/jbuilder@opam:transition@8c8ec590",
+        "@opam/easy-format@opam:1.3.1@85a6474a",
+        "@opam/conf-which@opam:1@2dd0e651", "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@opam/base-unix@opam:base@5229aaf3": {
+      "id": "@opam/base-unix@opam:base@5229aaf3",
+      "name": "@opam/base-unix",
+      "version": "opam:base",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "base-unix",
+          "version": "base",
+          "path": "esy.lock/opam/base-unix.base"
+        }
+      },
+      "overrides": [],
+      "dependencies": [ "@esy-ocaml/substs@0.0.1" ],
+      "devDependencies": []
+    },
+    "@opam/base-threads@opam:base@37e6a5c8": {
+      "id": "@opam/base-threads@opam:base@37e6a5c8",
+      "name": "@opam/base-threads",
+      "version": "opam:base",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "base-threads",
+          "version": "base",
+          "path": "esy.lock/opam/base-threads.base"
+        }
+      },
+      "overrides": [],
+      "dependencies": [ "@esy-ocaml/substs@0.0.1" ],
+      "devDependencies": []
+    },
+    "@opam/base-bytes@opam:base@75bd4047": {
+      "id": "@opam/base-bytes@opam:base@75bd4047",
+      "name": "@opam/base-bytes",
+      "version": "opam:base",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "base-bytes",
+          "version": "base",
+          "path": "esy.lock/opam/base-bytes.base"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/ocamlfind@opam:1.8.0@6fa9aaf5",
+        "@esy-ocaml/substs@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@esy-ocaml/substs@0.0.1": {
+      "id": "@esy-ocaml/substs@0.0.1",
+      "name": "@esy-ocaml/substs",
+      "version": "0.0.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@esy-ocaml/substs/-/substs-0.0.1.tgz#sha1:59ebdbbaedcda123fc7ed8fb2b302b7d819e9a46"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "@esy-ocaml/reason@3.3.7": {
+      "id": "@esy-ocaml/reason@3.3.7",
+      "name": "@esy-ocaml/reason",
+      "version": "3.3.7",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@esy-ocaml/reason/-/reason-3.3.7.tgz#sha1:4d75b8876807c4178c6fff2359962066bb69d944"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/result@opam:1.3@7af06772",
+        "@opam/ocamlfind@opam:1.8.0@6fa9aaf5",
+        "@opam/ocaml-migrate-parsetree@opam:1.1.0@48c1552a",
+        "@opam/merlin-extend@opam:0.3@77408bd7",
+        "@opam/menhir@opam:20171013@8c9fcad5",
+        "@opam/dune@opam:1.6.0@3042a2f0"
+      ],
+      "devDependencies": []
+    },
+    "@esy-ocaml/merlin@3.0.5005": {
+      "id": "@esy-ocaml/merlin@3.0.5005",
+      "name": "@esy-ocaml/merlin",
+      "version": "3.0.5005",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@esy-ocaml/merlin/-/merlin-3.0.5005.tgz#sha1:4a9e2b4df20672524603b7b1797b7761d5d0d9ad"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.9", "@opam/yojson@opam:1.4.1@008b9b27",
+        "@opam/ocamlfind@opam:1.8.0@6fa9aaf5", "@esy-ocaml/substs@0.0.1",
+        "@esy-ocaml/esy-installer@0.0.1"
+      ],
+      "devDependencies": []
+    },
+    "@esy-ocaml/esy-installer@0.0.1": {
+      "id": "@esy-ocaml/esy-installer@0.0.1",
+      "name": "@esy-ocaml/esy-installer",
+      "version": "0.0.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@esy-ocaml/esy-installer/-/esy-installer-0.0.1.tgz#sha1:420c65f7e5f9bafa3da578532c352acdf00837aa"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    }
+  }
+}

--- a/esy.lock/opam-override/dune.1.6.0/package.json
+++ b/esy.lock/opam-override/dune.1.6.0/package.json
@@ -1,0 +1,8 @@
+{
+  "override": {
+    "build": [
+      [ "ocaml", "bootstrap.ml" ],
+      [ "./boot.exe", "--release", "-j", "4" ]
+    ]
+  }
+}

--- a/esy.lock/opam-override/lambda-term.1.13/files/lambda-term-1.13.patch
+++ b/esy.lock/opam-override/lambda-term.1.13/files/lambda-term-1.13.patch
@@ -1,0 +1,88 @@
+--- ./src/lTerm_windows_stubs.c
++++ ./src/lTerm_windows_stubs.c
+@@ -16,7 +16,6 @@
+ 
+ #if defined(_WIN32) || defined(_WIN64)
+ 
+-#include <windows.h>
+ #include <lwt_unix.h>
+ 
+ /* +-----------------------------------------------------------------+
+@@ -140,15 +139,7 @@
+   }
+ }
+ 
+-CAMLprim value lt_windows_read_console_input_job(value val_fd)
+-{
+-  LWT_UNIX_INIT_JOB(job, read_console_input, 0);
+-  job->handle = Handle_val(val_fd);
+-  job->error_code = 0;
+-  CAMLreturn(lwt_unix_alloc_job(&(job->job)));
+-}
+-
+-static value result_read_console_input_result(struct job_read_console_input *job)
++static value result_read_console_input(struct job_read_console_input *job)
+ {
+   INPUT_RECORD input;
+   DWORD cks, bs;
+@@ -163,23 +154,23 @@
+     win32_maperr(error_code);
+     uerror("ReadConsoleInput", Nothing);
+   }
+-  switch (input->EventType) {
++  switch (input.EventType) {
+   case KEY_EVENT: {
+     result = caml_alloc(1, 0);
+     x = caml_alloc_tuple(4);
+     Field(result, 0) = x;
+-    cks = input->Event.KeyEvent.dwControlKeyState;
++    cks = input.Event.KeyEvent.dwControlKeyState;
+     Field(x, 0) = Val_bool((cks & LEFT_CTRL_PRESSED) | (cks & RIGHT_CTRL_PRESSED));
+     Field(x, 1) = Val_bool((cks & LEFT_ALT_PRESSED) | (cks & RIGHT_ALT_PRESSED));
+     Field(x, 2) = Val_bool(cks & SHIFT_PRESSED);
+-    code = input->Event.KeyEvent.wVirtualKeyCode;
++    code = input.Event.KeyEvent.wVirtualKeyCode;
+     for (i = 0; i < sizeof(code_table)/sizeof(code_table[0]); i++)
+       if (code == code_table[i]) {
+         Field(x, 3) = Val_int(i);
+         CAMLreturn(result);
+       }
+     y = caml_alloc_tuple(1);
+-    Field(y, 0) = Val_int(input->Event.KeyEvent.uChar.UnicodeChar);
++    Field(y, 0) = Val_int(input.Event.KeyEvent.uChar.UnicodeChar);
+     Field(x, 3) = y;
+     CAMLreturn(result);
+   }
+@@ -187,13 +178,13 @@
+     result = caml_alloc(1, 1);
+     x = caml_alloc_tuple(6);
+     Field(result, 0) = x;
+-    cks = input->Event.MouseEvent.dwControlKeyState;
++    cks = input.Event.MouseEvent.dwControlKeyState;
+     Field(x, 0) = Val_bool((cks & LEFT_CTRL_PRESSED) | (cks & RIGHT_CTRL_PRESSED));
+     Field(x, 1) = Val_bool((cks & LEFT_ALT_PRESSED) | (cks & RIGHT_ALT_PRESSED));
+     Field(x, 2) = Val_bool(cks & SHIFT_PRESSED);
+-    Field(x, 4) = Val_int(input->Event.MouseEvent.dwMousePosition.Y);
+-    Field(x, 5) = Val_int(input->Event.MouseEvent.dwMousePosition.X);
+-    bs = input->Event.MouseEvent.dwButtonState;
++    Field(x, 4) = Val_int(input.Event.MouseEvent.dwMousePosition.Y);
++    Field(x, 5) = Val_int(input.Event.MouseEvent.dwMousePosition.X);
++    bs = input.Event.MouseEvent.dwButtonState;
+     if (bs & FROM_LEFT_1ST_BUTTON_PRESSED)
+       Field(x, 3) = Val_int(0);
+     else if (bs & FROM_LEFT_2ND_BUTTON_PRESSED)
+@@ -212,6 +203,14 @@
+   CAMLreturn(Val_int(0));
+ }
+ 
++CAMLprim value lt_windows_read_console_input_job(value val_fd)
++{
++  LWT_UNIX_INIT_JOB(job, read_console_input, 0);
++  job->handle = Handle_val(val_fd);
++  job->error_code = 0;
++  return (lwt_unix_alloc_job(&(job->job)));
++}
++
+ /* +-----------------------------------------------------------------+
+    | Console informations                                            |
+    +-----------------------------------------------------------------+ */

--- a/esy.lock/opam-override/lambda-term.1.13/package.json
+++ b/esy.lock/opam-override/lambda-term.1.13/package.json
@@ -1,0 +1,11 @@
+{
+  "override": {
+    "build": [
+      [
+        "bash", "-c",
+        "#{os == 'windows' ? 'patch -p1 < lambda-term-1.13.patch' : 'true'}"
+      ],
+      [ "jbuilder", "build", "-p", "lambda-term", "-j", "4" ]
+    ]
+  }
+}

--- a/esy.lock/opam-override/menhir.20171013/files/menhir-20171013.patch
+++ b/esy.lock/opam-override/menhir.20171013/files/menhir-20171013.patch
@@ -1,0 +1,40 @@
+--- ./Makefile
++++ ./Makefile
+@@ -59,13 +59,8 @@
+ 
+ # If the compiler is MSVC, then object file names end in .obj instead of .o.
+ 
+-ifneq (,$(shell ocamlc -config | grep -E "ccomp_type: msvc"))
+-  OBJ          := obj
+-# LIBSUFFIX    := lib
+-else
+-  OBJ          := o
+-# LIBSUFFIX    := a
+-endif
++OBJ          := $(shell ocamlc -config | awk -F '[\t \r]+' '/^ext_obj:/ {print $$2}' | tr -d '.')
++#LIBSUFFIX   := $(shell ocamlc -config | awk -F '[\t \r]+' '/^ext_lib:/ {print $$2}' | tr -d '.')
+ 
+ # If we are under Windows (regardless of whether we are using MSVC or mingw)
+ # then the name of the executable file ends in .exe.
+@@ -91,8 +86,9 @@
+ # performed if "os_type" is "Win32" or "Win64", and must not be performed if
+ # "os_type" is "Cygwin" or "Unix".
+ 
+-ifneq (,$(shell ocamlc -config | grep -E "os_type: (Win32|Win64)"))
+-installation_libdir := $(shell cygpath -m $(libdir))
++OS_TYPE:=	$(shell ocamlc -config | awk -F '[\t \r]+' '/^os_type:/ {print $$2}')
++ifeq ($(OS_TYPE),Win32)
++installation_libdir := $(shell cygpath -m $(libdir) || echo $(libdir))
+ else
+ installation_libdir := $(libdir)
+ endif
+--- ./src/cmly_write.ml
++++ ./src/cmly_write.ml
+@@ -168,6 +168,6 @@
+   output_value oc (t : grammar)
+ 
+ let write filename =
+-  let oc = open_out filename in
++  let oc = open_out_bin filename in
+   write oc (encode());
+   close_out oc

--- a/esy.lock/opam-override/menhir.20171013/package.json
+++ b/esy.lock/opam-override/menhir.20171013/package.json
@@ -1,0 +1,15 @@
+{
+  "override": {
+    "build": [
+      [
+        "bash", "-c",
+        "#{os == 'windows' ? 'patch -p1 < menhir-20171013.patch' : 'true'}"
+      ],
+      [
+        "make", "-f", "Makefile", "PREFIX=#{self.install}",
+        "USE_OCAMLFIND=true", "docdir=#{self.doc}/menhir",
+        "libdir=#{self.lib}/menhir", "mandir=#{self.man}/man1"
+      ]
+    ]
+  }
+}

--- a/esy.lock/opam-override/merlin-extend.0.3/files/merlin-extend-winfix.patch
+++ b/esy.lock/opam-override/merlin-extend.0.3/files/merlin-extend-winfix.patch
@@ -1,0 +1,34 @@
+--- ./extend_helper.ml
++++ ./extend_helper.ml
+@@ -1,13 +1,6 @@
+-(*pp cppo -V OCAML:`ocamlc -version` *)
+ open Parsetree
+ open Extend_protocol
+ 
+-#if OCAML_VERSION < (4, 3, 0)
+-# define CONST_STRING Asttypes.Const_string
+-#else
+-# define CONST_STRING Parsetree.Pconst_string
+-#endif
+-
+ (** Default implementation for [Reader_def.print_outcome] using
+     [Oprint] from compiler-libs *)
+ let print_outcome_using_oprint ppf = function
+@@ -28,7 +21,7 @@
+       pstr_loc = Location.none;
+       pstr_desc = Pstr_eval ({
+           pexp_loc = Location.none;
+-          pexp_desc = Pexp_constant (CONST_STRING (msg, None));
++          pexp_desc = Pexp_constant (Parsetree.Pconst_string (msg, None));
+           pexp_attributes = [];
+         }, []);
+     }]
+@@ -112,7 +105,7 @@
+   let msg = match payload with
+     | PStr [{
+         pstr_desc = Pstr_eval ({
+-            pexp_desc = Pexp_constant (CONST_STRING (msg, _));
++            pexp_desc = Pexp_constant (Parsetree.Pconst_string (msg, _));
+           }, _);
+       }] -> msg
+     | _ -> "Warning: extension produced an incorrect syntax-error node"

--- a/esy.lock/opam-override/merlin-extend.0.3/package.json
+++ b/esy.lock/opam-override/merlin-extend.0.3/package.json
@@ -1,0 +1,11 @@
+{
+  "override": {
+    "build": [
+      [
+        "bash", "-c",
+        "#{os == 'windows' ? 'patch -p1 < merlin-extend-winfix.patch' : 'true'}"
+      ],
+      [ "make" ]
+    ]
+  }
+}

--- a/esy.lock/opam-override/ocamlbuild.0.12.0/files/ocamlbuild-0.12.0.patch
+++ b/esy.lock/opam-override/ocamlbuild.0.12.0/files/ocamlbuild-0.12.0.patch
@@ -1,0 +1,463 @@
+--- ./Makefile
++++ ./Makefile
+@@ -213,7 +213,7 @@
+ 	rm -f man/ocamlbuild.1
+ 
+ man/options_man.byte: src/ocamlbuild_pack.cmo
+-	$(OCAMLC) $^ -I src man/options_man.ml -o man/options_man.byte
++	$(OCAMLC) -I +unix unix.cma $^ -I src man/options_man.ml -o man/options_man.byte
+ 
+ clean::
+ 	rm -f man/options_man.cm*
+--- ./src/command.ml
++++ ./src/command.ml
+@@ -148,9 +148,10 @@
+   let self = string_of_command_spec_with_calls call_with_tags call_with_target resolve_virtuals in
+   let b = Buffer.create 256 in
+   (* The best way to prevent bash from switching to its windows-style
+-   * quote-handling is to prepend an empty string before the command name. *)
++   * quote-handling is to prepend an empty string before the command name.
++   * space seems to work, too - and the ouput is nicer *)
+   if Sys.os_type = "Win32" then
+-    Buffer.add_string b "''";
++    Buffer.add_char b ' ';
+   let first = ref true in
+   let put_space () =
+     if !first then
+@@ -260,7 +261,7 @@
+ 
+ let execute_many ?(quiet=false) ?(pretend=false) cmds =
+   add_parallel_stat (List.length cmds);
+-  let degraded = !*My_unix.is_degraded || Sys.os_type = "Win32" in
++  let degraded = !*My_unix.is_degraded in
+   let jobs = !jobs in
+   if jobs < 0 then invalid_arg "jobs < 0";
+   let max_jobs = if jobs = 0 then None else Some jobs in
+--- ./src/findlib.ml
++++ ./src/findlib.ml
+@@ -66,9 +66,6 @@
+     (fun command -> lexer & Lexing.from_string & run_and_read command)
+     command
+ 
+-let run_and_read command =
+-  Printf.ksprintf run_and_read command
+-
+ let rec query name =
+   try
+     Hashtbl.find packages name
+@@ -135,7 +132,8 @@
+   with Not_found -> s
+ 
+ let list () =
+-  List.map before_space (split_nl & run_and_read "%s list" ocamlfind)
++  let cmd = Shell.quote_filename_if_needed ocamlfind ^ " list" in
++  List.map before_space (split_nl & run_and_read cmd)
+ 
+ (* The closure algorithm is easy because the dependencies are already closed
+ and sorted for each package. We only have to make the union. We could also
+--- ./src/main.ml
++++ ./src/main.ml
+@@ -162,6 +162,9 @@
+               Tags.mem "traverse" tags
+               || List.exists (Pathname.is_prefix path_name) !Options.include_dirs
+               || List.exists (Pathname.is_prefix path_name) target_dirs)
++            && ((* beware: !Options.build_dir is an absolute directory *)
++              Pathname.normalize !Options.build_dir
++              <> Pathname.normalize (Pathname.pwd/path_name))
+           end
+         end
+       end
+--- ./src/my_std.ml
++++ ./src/my_std.ml
+@@ -271,13 +271,107 @@
+       try Array.iter (fun x -> if x = basename then raise Exit) a; false
+       with Exit -> true
+ 
++let command_plain = function
++| [| |] -> 0
++| margv ->
++  let rec waitpid a b =
++    match Unix.waitpid a b with
++    | exception (Unix.Unix_error(Unix.EINTR,_,_)) -> waitpid a b
++    | x -> x
++  in
++  let pid = Unix.(create_process margv.(0) margv stdin stdout stderr) in
++  let pid', process_status = waitpid [] pid in
++  assert (pid = pid');
++  match process_status with
++  | Unix.WEXITED n -> n
++  | Unix.WSIGNALED _ -> 2 (* like OCaml's uncaught exceptions *)
++  | Unix.WSTOPPED _ -> 127
++
++(* can't use Lexers because of circular dependency *)
++let split_path_win str =
++  let rec aux pos =
++    try
++      let i = String.index_from str pos ';' in
++      let len = i - pos in
++      if len = 0 then
++        aux (succ i)
++      else
++        String.sub str pos (i - pos) :: aux (succ i)
++    with Not_found | Invalid_argument _ ->
++      let len = String.length str - pos in
++      if len = 0 then [] else [String.sub str pos len]
++  in
++  aux 0
++
++let windows_shell = lazy begin
++  let rec iter = function
++  | [] -> [| "bash.exe" ; "--norc" ; "--noprofile" |]
++  | hd::tl ->
++    let dash = Filename.concat hd "dash.exe" in
++    if Sys.file_exists dash then [|dash|] else
++    let bash = Filename.concat hd "bash.exe" in
++    if Sys.file_exists bash = false then iter tl else
++    (* if sh.exe and bash.exe exist in the same dir, choose sh.exe *)
++    let sh = Filename.concat hd "sh.exe" in
++    if Sys.file_exists sh then [|sh|] else [|bash ; "--norc" ; "--noprofile"|]
++  in
++  split_path_win (try Sys.getenv "PATH" with Not_found -> "") |> iter
++end
++
++let prep_windows_cmd cmd =
++  (* workaround known ocaml bug, remove later *)
++  if String.contains cmd '\t' && String.contains cmd ' ' = false then
++    " " ^ cmd
++  else
++    cmd
++
++let run_with_shell = function
++| "" -> 0
++| cmd ->
++  let cmd = prep_windows_cmd cmd in
++  let shell = Lazy.force windows_shell in
++  let qlen = Filename.quote cmd |> String.length in
++  (* old versions of dash had problems with bs *)
++  try
++    if qlen < 7_900 then
++      command_plain (Array.append shell [| "-ec" ; cmd |])
++    else begin
++      (* it can still work, if the called command is a cygwin tool *)
++      let ch_closed = ref false in
++      let file_deleted = ref false in
++      let fln,ch =
++        Filename.open_temp_file
++          ~mode:[Open_binary]
++          "ocamlbuildtmp"
++          ".sh"
++      in
++      try
++        let f_slash = String.map ( fun x -> if x = '\\' then '/' else x ) fln in
++        output_string ch cmd;
++        ch_closed:= true;
++        close_out ch;
++        let ret = command_plain (Array.append shell [| "-e" ; f_slash |]) in
++        file_deleted:= true;
++        Sys.remove fln;
++        ret
++      with
++      | x ->
++        if !ch_closed = false then
++          close_out_noerr ch;
++        if !file_deleted = false then
++          (try Sys.remove fln with _ -> ());
++        raise x
++    end
++  with
++  | (Unix.Unix_error _) as x ->
++    (* Sys.command doesn't raise an exception, so run_with_shell also won't
++       raise *)
++    Printexc.to_string x ^ ":" ^ cmd |> prerr_endline;
++    1
++
+ let sys_command =
+-  match Sys.os_type with
+-  | "Win32" -> fun cmd ->
+-      if cmd = "" then 0 else
+-      let cmd = "bash --norc -c " ^ Filename.quote cmd in
+-      Sys.command cmd
+-  | _ -> fun cmd -> if cmd = "" then 0 else Sys.command cmd
++  if Sys.win32 then run_with_shell
++  else fun cmd -> if cmd = "" then 0 else Sys.command cmd
+ 
+ (* FIXME warning fix and use Filename.concat *)
+ let filename_concat x y =
+--- ./src/my_std.mli
++++ ./src/my_std.mli
+@@ -69,3 +69,6 @@
+ 
+ val split_ocaml_version : (int * int * int * string) option
+ (** (major, minor, patchlevel, rest) *)
++
++val windows_shell : string array Lazy.t
++val prep_windows_cmd : string -> string
+--- ./src/ocamlbuild_executor.ml
++++ ./src/ocamlbuild_executor.ml
+@@ -34,6 +34,8 @@
+   job_stdin   : out_channel;
+   job_stderr  : in_channel;
+   job_buffer  : Buffer.t;
++  job_pid     : int;
++  job_tmp_file: string option;
+   mutable job_dying : bool;
+ };;
+ 
+@@ -76,6 +78,61 @@
+   in
+   loop 0
+ ;;
++
++let open_process_full_win cmd env =
++  let (in_read, in_write) = Unix.pipe () in
++  let (out_read, out_write) = Unix.pipe () in
++  let (err_read, err_write) = Unix.pipe () in
++  Unix.set_close_on_exec in_read;
++  Unix.set_close_on_exec out_write;
++  Unix.set_close_on_exec err_read;
++  let inchan = Unix.in_channel_of_descr in_read in
++  let outchan = Unix.out_channel_of_descr out_write in
++  let errchan = Unix.in_channel_of_descr err_read in
++  let shell = Lazy.force Ocamlbuild_pack.My_std.windows_shell in
++  let test_cmd =
++    String.concat " " (List.map Filename.quote (Array.to_list shell)) ^
++    "-ec " ^
++    Filename.quote (Ocamlbuild_pack.My_std.prep_windows_cmd cmd) in
++  let argv,tmp_file =
++    if String.length test_cmd < 7_900 then
++      Array.append
++        shell
++        [| "-ec" ; Ocamlbuild_pack.My_std.prep_windows_cmd cmd |],None
++    else
++    let fln,ch = Filename.open_temp_file ~mode:[Open_binary] "ocamlbuild" ".sh" in
++    output_string ch (Ocamlbuild_pack.My_std.prep_windows_cmd cmd);
++    close_out ch;
++    let fln' = String.map (function '\\' -> '/' | c -> c) fln in
++    Array.append
++      shell
++      [| "-c" ; fln' |], Some fln in
++  let pid =
++    Unix.create_process_env argv.(0) argv env out_read in_write err_write in
++  Unix.close out_read;
++  Unix.close in_write;
++  Unix.close err_write;
++  (pid, inchan, outchan, errchan,tmp_file)
++
++let close_process_full_win (pid,inchan, outchan, errchan, tmp_file) =
++  let delete tmp_file =
++    match tmp_file with
++    | None -> ()
++    | Some x -> try Sys.remove x with Sys_error _ -> () in
++  let tmp_file_deleted = ref false in
++  try
++    close_in inchan;
++    close_out outchan;
++    close_in errchan;
++    let res = snd(Unix.waitpid [] pid) in
++    tmp_file_deleted := true;
++    delete tmp_file;
++    res
++  with
++  | x when tmp_file <> None && !tmp_file_deleted = false ->
++    delete tmp_file;
++    raise x
++
+ (* ***)
+ (*** execute *)
+ (* XXX: Add test for non reentrancy *)
+@@ -130,10 +187,16 @@
+   (*** add_job *)
+   let add_job cmd rest result id =
+     (*display begin fun oc -> fp oc "Job %a is %s\n%!" print_job_id id cmd; end;*)
+-    let (stdout', stdin', stderr') = open_process_full cmd env in
++    let (pid,stdout', stdin', stderr', tmp_file) =
++      if Sys.win32 then open_process_full_win cmd env else
++      let a,b,c = open_process_full cmd env in
++      -1,a,b,c,None
++    in
+     incr jobs_active;
+-    set_nonblock (doi stdout');
+-    set_nonblock (doi stderr');
++    if not Sys.win32 then (
++      set_nonblock (doi stdout');
++      set_nonblock (doi stderr');
++    );
+     let job =
+       { job_id          = id;
+         job_command     = cmd;
+@@ -143,7 +206,9 @@
+         job_stdin       = stdin';
+         job_stderr      = stderr';
+         job_buffer      = Buffer.create 1024;
+-        job_dying       = false }
++        job_dying       = false;
++        job_tmp_file    = tmp_file;
++        job_pid         = pid }
+     in
+     outputs := FDM.add (doi stdout') job (FDM.add (doi stderr') job !outputs);
+     jobs := JS.add job !jobs;
+@@ -199,6 +264,7 @@
+               try
+                 read fd u 0 (Bytes.length u)
+               with
++              | Unix.Unix_error(Unix.EPIPE,_,_) when Sys.win32 -> 0
+               | Unix.Unix_error(e,_,_)  ->
+                 let msg = error_message e in
+                 display (fun oc -> fp oc
+@@ -241,14 +307,19 @@
+       decr jobs_active;
+ 
+       (* PR#5371: we would get EAGAIN below otherwise *)
+-      clear_nonblock (doi job.job_stdout);
+-      clear_nonblock (doi job.job_stderr);
+-
++      if not Sys.win32 then (
++        clear_nonblock (doi job.job_stdout);
++        clear_nonblock (doi job.job_stderr);
++      );
+       do_read ~loop:true (doi job.job_stdout) job;
+       do_read ~loop:true (doi job.job_stderr) job;
+       outputs := FDM.remove (doi job.job_stdout) (FDM.remove (doi job.job_stderr) !outputs);
+       jobs := JS.remove job !jobs;
+-      let status = close_process_full (job.job_stdout, job.job_stdin, job.job_stderr) in
++      let status =
++        if Sys.win32 then
++          close_process_full_win (job.job_pid, job.job_stdout, job.job_stdin, job.job_stderr, job.job_tmp_file)
++        else
++          close_process_full (job.job_stdout, job.job_stdin, job.job_stderr) in
+ 
+       let shown = ref false in
+ 
+--- ./src/ocamlbuild_unix_plugin.ml
++++ ./src/ocamlbuild_unix_plugin.ml
+@@ -48,12 +48,22 @@
+   end
+ 
+ let run_and_open s kont =
++  let s_orig = s in
++  let s =
++    (* Be consistent! My_unix.run_and_open uses My_std.sys_command and
++       sys_command uses bash. *)
++    if Sys.win32 = false then s else
++    let l = match Lazy.force My_std.windows_shell |> Array.to_list with
++    | hd::tl -> (Filename.quote hd)::tl
++    | _ -> assert false in
++    "\"" ^ (String.concat " " l) ^ " -ec " ^ Filename.quote (" " ^ s) ^ "\""
++  in
+   let ic = Unix.open_process_in s in
+   let close () =
+     match Unix.close_process_in ic with
+     | Unix.WEXITED 0 -> ()
+     | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->
+-        failwith (Printf.sprintf "Error while running: %s" s) in
++        failwith (Printf.sprintf "Error while running: %s" s_orig) in
+   let res = try
+       kont ic
+     with e -> (close (); raise e)
+--- ./src/options.ml
++++ ./src/options.ml
+@@ -174,11 +174,24 @@
+     build_dir := Filename.concat (Sys.getcwd ()) s
+   else
+     build_dir := s
++
++let slashify =
++  if Sys.win32 then fun p -> String.map (function '\\' -> '/' | x -> x) p
++  else fun p ->p
++
++let sb () =
++  match Sys.os_type with
++  | "Win32" ->
++    (try set_binary_mode_out stdout true with _ -> ());
++  | _ -> ()
++
++
+ let spec = ref (
+     let print_version () =
++      sb ();
+       Printf.printf "ocamlbuild %s\n%!" Ocamlbuild_config.version; raise Exit_OK
+     in
+-    let print_vnum () = print_endline Ocamlbuild_config.version; raise Exit_OK in
++    let print_vnum () = sb (); print_endline Ocamlbuild_config.version; raise Exit_OK in
+   Arg.align
+   [
+    "-version", Unit print_version , " Display the version";
+@@ -257,8 +270,8 @@
+    "-build-dir", String set_build_dir, "<path> Set build directory (implies no-links)";
+    "-install-lib-dir", Set_string Ocamlbuild_where.libdir, "<path> Set the install library directory";
+    "-install-bin-dir", Set_string Ocamlbuild_where.bindir, "<path> Set the install binary directory";
+-   "-where", Unit (fun () -> print_endline !Ocamlbuild_where.libdir; raise Exit_OK), " Display the install library directory";
+-   "-which", String (fun cmd -> print_endline (find_tool cmd); raise Exit_OK), "<command> Display path to the tool command";
++   "-where", Unit (fun () -> sb (); print_endline (slashify !Ocamlbuild_where.libdir); raise Exit_OK), " Display the install library directory";
++   "-which", String (fun cmd -> sb (); print_endline (slashify (find_tool cmd)); raise Exit_OK), "<command> Display path to the tool command";
+    "-ocamlc", set_cmd ocamlc, "<command> Set the OCaml bytecode compiler";
+    "-plugin-ocamlc", set_cmd plugin_ocamlc, "<command> Set the OCaml bytecode compiler \
+      used when building myocamlbuild.ml (only)";
+--- ./src/pathname.ml
++++ ./src/pathname.ml
+@@ -84,6 +84,26 @@
+   | x :: xs -> x :: normalize_list xs
+ 
+ let normalize x =
++  let x =
++    if Sys.win32 = false then
++      x
++    else
++      let len = String.length x in
++      let b = Bytes.create len in
++      for i = 0 to pred len do
++        match x.[i] with
++        | '\\' -> Bytes.set b i '/'
++        | c -> Bytes.set b i c
++      done;
++      if len > 1 then (
++        let c1 = Bytes.get b 0 in
++        let c2 = Bytes.get b 1 in
++        if c2 = ':' && c1 >= 'a' && c1 <= 'z' &&
++           ( len = 2 || Bytes.get b 2 = '/') then
++          Bytes.set b 0 (Char.uppercase_ascii c1)
++      );
++      Bytes.unsafe_to_string b
++  in
+   if Glob.eval not_normal_form_re x then
+     let root, paths = split x in
+     join root (normalize_list paths)
+--- ./src/shell.ml
++++ ./src/shell.ml
+@@ -24,12 +24,26 @@
+     | 'a'..'z' | 'A'..'Z' | '0'..'9' | '.' | '-' | '/' | '_' | ':' | '@' | '+' | ',' -> loop (pos + 1)
+     | _ -> false in
+   loop 0
++
++let generic_quote quotequote s =
++  let l = String.length s in
++  let b = Buffer.create (l + 20) in
++  Buffer.add_char b '\'';
++  for i = 0 to l - 1 do
++    if s.[i] = '\''
++    then Buffer.add_string b quotequote
++    else Buffer.add_char b  s.[i]
++  done;
++  Buffer.add_char b '\'';
++  Buffer.contents b
++let unix_quote = generic_quote "'\\''"
++
+ let quote_filename_if_needed s =
+   if is_simple_filename s then s
+   (* We should probably be using [Filename.unix_quote] except that function
+    * isn't exported. Users on Windows will have to live with not being able to
+    * install OCaml into c:\o'caml. Too bad. *)
+-  else if Sys.os_type = "Win32" then Printf.sprintf "'%s'" s
++  else if Sys.os_type = "Win32" then unix_quote s
+   else Filename.quote s
+ let chdir dir =
+   reset_filesys_cache ();
+@@ -37,7 +51,7 @@
+ let run args target =
+   reset_readdir_cache ();
+   let cmd = String.concat " " (List.map quote_filename_if_needed args) in
+-  if !*My_unix.is_degraded || Sys.os_type = "Win32" then
++  if !*My_unix.is_degraded then
+     begin
+       Log.event cmd target Tags.empty;
+       let st = sys_command cmd in

--- a/esy.lock/opam-override/ocamlbuild.0.12.0/package.json
+++ b/esy.lock/opam-override/ocamlbuild.0.12.0/package.json
@@ -1,0 +1,20 @@
+{
+  "override": {
+    "build": [
+      [
+        "bash", "-c",
+        "#{os == 'windows' ? 'patch -p1 < ocamlbuild-0.12.0.patch' : 'true'}"
+      ],
+      [
+        "make", "-f", "configure.make", "all",
+        "OCAMLBUILD_PREFIX=#{self.install}", "OCAMLBUILD_BINDIR=#{self.bin}",
+        "OCAMLBUILD_LIBDIR=#{self.lib}", "OCAMLBUILD_MANDIR=#{self.man}",
+        "OCAMLBUILD_NATIVE=true", "OCAMLBUILD_NATIVE_TOOLS=true"
+      ],
+      [
+        "make", "check-if-preinstalled", "all",
+        "#{os == 'windows' ? 'install' : 'opam-install'}"
+      ]
+    ]
+  }
+}

--- a/esy.lock/opam-override/ocamlfind.1.8.0/files/findlib-1.8.0.patch
+++ b/esy.lock/opam-override/ocamlfind.1.8.0/files/findlib-1.8.0.patch
@@ -1,0 +1,489 @@
+--- ./Makefile
++++ ./Makefile
+@@ -57,16 +57,16 @@
+ 	cat findlib.conf.in | \
+ 	    $(SH) tools/patch '@SITELIB@' '$(OCAML_SITELIB)' >findlib.conf
+ 	if ./tools/cmd_from_same_dir ocamlc; then \
+-		echo 'ocamlc="ocamlc.opt"' >>findlib.conf; \
++		echo 'ocamlc="ocamlc.opt$(EXEC_SUFFIX)"' >>findlib.conf; \
+ 	fi
+ 	if ./tools/cmd_from_same_dir ocamlopt; then \
+-		echo 'ocamlopt="ocamlopt.opt"' >>findlib.conf; \
++		echo 'ocamlopt="ocamlopt.opt$(EXEC_SUFFIX)"' >>findlib.conf; \
+ 	fi
+ 	if ./tools/cmd_from_same_dir ocamldep; then \
+-		echo 'ocamldep="ocamldep.opt"' >>findlib.conf; \
++		echo 'ocamldep="ocamldep.opt$(EXEC_SUFFIX)"' >>findlib.conf; \
+ 	fi
+ 	if ./tools/cmd_from_same_dir ocamldoc; then \
+-		echo 'ocamldoc="ocamldoc.opt"' >>findlib.conf; \
++		echo 'ocamldoc="ocamldoc.opt$(EXEC_SUFFIX)"' >>findlib.conf; \
+ 	fi
+ 
+ .PHONY: install-doc
+--- ./src/findlib/findlib_config.mlp
++++ ./src/findlib/findlib_config.mlp
+@@ -24,3 +24,5 @@
+     | "MacOS" -> ""        (* don't know *)
+     | _ -> failwith "Unknown Sys.os_type"
+ ;;
++
++let exec_suffix = "@EXEC_SUFFIX@";;
+--- ./src/findlib/findlib.ml
++++ ./src/findlib/findlib.ml
+@@ -28,15 +28,20 @@
+ let conf_ldconf = ref "";;
+ let conf_ignore_dups_in = ref ([] : string list);;
+ 
+-let ocamlc_default = "ocamlc";;
+-let ocamlopt_default = "ocamlopt";;
+-let ocamlcp_default = "ocamlcp";;
+-let ocamloptp_default = "ocamloptp";;
+-let ocamlmklib_default = "ocamlmklib";;
+-let ocamlmktop_default = "ocamlmktop";;
+-let ocamldep_default = "ocamldep";;
+-let ocamlbrowser_default = "ocamlbrowser";;
+-let ocamldoc_default = "ocamldoc";;
++let add_exec str =
++  match Findlib_config.exec_suffix with
++  | "" -> str
++  | a  -> str ^ a ;;
++let ocamlc_default = add_exec "ocamlc";;
++let ocamlopt_default = add_exec "ocamlopt";;
++let ocamlcp_default = add_exec "ocamlcp";;
++let ocamloptp_default = add_exec "ocamloptp";;
++let ocamlmklib_default = add_exec "ocamlmklib";;
++let ocamlmktop_default = add_exec "ocamlmktop";;
++let ocamldep_default = add_exec "ocamldep";;
++let ocamlbrowser_default = add_exec "ocamlbrowser";;
++let ocamldoc_default = add_exec "ocamldoc";;
++
+ 
+ 
+ let init_manually 
+--- ./src/findlib/fl_package_base.ml
++++ ./src/findlib/fl_package_base.ml
+@@ -133,7 +133,15 @@
+ 	  List.find (fun def -> def.def_var = "exists_if") p.package_defs  in
+ 	let files = Fl_split.in_words def.def_value in
+ 	List.exists 
+-	  (fun file -> Sys.file_exists (Filename.concat d' file))
++	  (fun file ->
++            let fln = Filename.concat d' file in
++            let e = Sys.file_exists fln in
++            (* necessary for ppx executables *)
++            if e || Sys.os_type <> "Win32" || Filename.check_suffix fln ".exe" then
++              e
++            else
++              Sys.file_exists (fln ^ ".exe")
++          )
+ 	  files
+       with Not_found -> true in
+ 
+--- ./src/findlib/fl_split.ml
++++ ./src/findlib/fl_split.ml
+@@ -126,10 +126,17 @@
+     | '/' | '\\' -> true
+     | _ -> false in
+   let norm_dir_win() =
+-    if l >= 1 && s.[0] = '/' then
+-      Buffer.add_char b '\\' else Buffer.add_char b s.[0];
+-    if l >= 2 && s.[1] = '/' then
+-      Buffer.add_char b '\\' else Buffer.add_char b s.[1];
++    if l >= 1 then (
++      if s.[0] = '/' then
++        Buffer.add_char b '\\'
++      else
++        Buffer.add_char b s.[0] ;
++      if l >= 2 then
++        if s.[1] = '/' then
++          Buffer.add_char b '\\'
++        else
++          Buffer.add_char b s.[1];
++    );
+     for k = 2 to l - 1 do
+       let c = s.[k] in
+       if is_slash c then (
+--- ./src/findlib/frontend.ml
++++ ./src/findlib/frontend.ml
+@@ -31,10 +31,18 @@
+   else
+     Sys_error (arg ^ ": " ^ Unix.error_message code)
+ 
++let is_win = Sys.os_type = "Win32"
++
++let () =
++  match Findlib_config.system with
++    | "win32" | "win64" | "mingw" | "cygwin" | "mingw64" | "cygwin64" ->
++      (try set_binary_mode_out stdout true with _ -> ());
++      (try set_binary_mode_out stderr true with _ -> ());
++    | _ -> ()
+ 
+ let slashify s =
+   match Findlib_config.system with
+-    | "mingw" | "mingw64" | "cygwin" ->
++    | "win32" | "win64" | "mingw" | "cygwin" | "mingw64" | "cygwin64" ->
+         let b = Buffer.create 80 in
+         String.iter
+           (function
+@@ -49,7 +57,7 @@
+ 
+ let out_path ?(prefix="") s =
+   match Findlib_config.system with
+-    | "mingw" | "mingw64" | "cygwin" ->
++   | "win32" | "win64" | "mingw" | "mingw64" | "cygwin" ->
+ 	let u = slashify s in
+ 	prefix ^ 
+ 	  (if String.contains u ' ' then
+@@ -273,11 +281,9 @@
+ 
+ 
+ let identify_dir d =
+-  match Sys.os_type with
+-    | "Win32" ->
+-	failwith "identify_dir"   (* not available *)
+-    | _ ->
+-	let s = Unix.stat d in
++  if is_win then
++    failwith "identify_dir";   (* not available *)
++  let s = Unix.stat d in
+ 	(s.Unix.st_dev, s.Unix.st_ino)
+ ;;
+ 
+@@ -459,6 +465,96 @@
+       )
+       packages
+ 
++let rewrite_cmd s =
++  if s = "" || not is_win then
++    s
++  else
++    let s =
++      let l = String.length s in
++      let b = Buffer.create l in
++      for i = 0 to pred l do
++        match s.[i] with
++        | '/' -> Buffer.add_char b '\\'
++        | x -> Buffer.add_char b x
++      done;
++      Buffer.contents b
++    in
++    if (Filename.is_implicit s && String.contains s '\\' = false) ||
++      Filename.check_suffix (String.lowercase s) ".exe" then
++      s
++    else
++      let s' = s ^ ".exe" in
++      if Sys.file_exists s' then
++        s'
++      else
++        s
++
++let rewrite_cmd s =
++  if s = "" || not is_win then s else
++  let s =
++    let l = String.length s in
++    let b = Buffer.create l in
++    for i = 0 to pred l do
++      match s.[i] with
++      | '/' -> Buffer.add_char b '\\'
++      | x -> Buffer.add_char b x
++    done;
++    Buffer.contents b
++  in
++  if (Filename.is_implicit s && String.contains s '\\' = false) ||
++     Filename.check_suffix (String.lowercase s) ".exe" then
++    s
++  else
++    let s' = s ^ ".exe" in
++    if Sys.file_exists s' then
++      s'
++    else
++      s
++
++let rewrite_pp cmd =
++  if not is_win then cmd else
++  let module T = struct exception Keep end in
++  let is_whitespace = function
++  | ' ' | '\011' | '\012' | '\n' | '\r' | '\t' -> true
++  | _ -> false in
++  (* characters that triggers special behaviour (cmd.exe, not unix shell) *)
++  let is_unsafe_char = function
++  | '(' | ')' | '%' | '!' | '^' | '<' | '>' | '&' -> true
++  | _ -> false in
++  let len = String.length cmd in
++  let buf = Buffer.create (len + 4) in
++  let buf_cmd = Buffer.create len in
++  let rec iter_ws i =
++    if i >= len then () else
++    let cur = cmd.[i] in
++    if is_whitespace cur then (
++      Buffer.add_char buf cur;
++      iter_ws (succ i)
++    )
++    else
++      iter_cmd i
++  and iter_cmd i =
++    if i >= len then add_buf_cmd () else
++    let cur = cmd.[i] in
++    if is_unsafe_char cur || cur = '"' || cur = '\'' then
++      raise T.Keep;
++    if is_whitespace cur then (
++      add_buf_cmd ();
++      Buffer.add_substring buf cmd i (len - i)
++    )
++    else (
++      Buffer.add_char buf_cmd cur;
++      iter_cmd (succ i)
++    )
++  and add_buf_cmd () =
++    if Buffer.length buf_cmd > 0 then
++      Buffer.add_string buf (rewrite_cmd (Buffer.contents buf_cmd))
++  in
++  try
++    iter_ws 0;
++    Buffer.contents buf
++  with
++  | T.Keep -> cmd
+ 
+ let process_pp_spec syntax_preds packages pp_opts =
+   (* Returns: pp_command *)
+@@ -549,7 +645,7 @@
+       None -> []
+     | Some cmd ->
+ 	["-pp";
+-	 cmd ^ " " ^
++	 (rewrite_cmd cmd) ^ " " ^
+ 	 String.concat " " (List.map Filename.quote pp_i_options) ^ " " ^
+ 	 String.concat " " (List.map Filename.quote pp_archives) ^ " " ^
+ 	 String.concat " " (List.map Filename.quote pp_opts)]
+@@ -625,9 +721,11 @@
+           in
+           try
+             let preprocessor =
++              rewrite_cmd (
+               resolve_path
+                 ~base ~explicit:true
+-                (package_property predicates pname "ppx") in
++                  (package_property predicates pname "ppx") )
++            in
+             ["-ppx"; String.concat " " (preprocessor :: options)]
+           with Not_found -> []
+        )
+@@ -895,6 +993,14 @@
+        switch (e.g. -L<path> instead of -L <path>)
+      *)
+ 
++(* We may need to remove files on which we do not have complete control.
++   On Windows, removing a read-only file fails so try to change the
++   mode of the file first. *)
++let remove_file fname =
++  try Sys.remove fname
++  with Sys_error _ when is_win ->
++    (try Unix.chmod fname 0o666 with Unix.Unix_error _ -> ());
++    Sys.remove fname
+ 
+ let ocamlc which () =
+ 
+@@ -1022,9 +1128,12 @@
+               
+ 	      "-intf", 
+ 	      Arg.String (fun s -> pass_files := !pass_files @ [ Intf(slashify s) ]);
+-              
++
+ 	      "-pp", 
+-	      Arg.String (fun s -> pp_specified := true; add_spec_fn "-pp" s);
++	      Arg.String (fun s -> pp_specified := true; add_spec_fn "-pp" (rewrite_pp s));
++
++              "-ppx",
++              Arg.String (fun s -> add_spec_fn "-ppx" (rewrite_pp s));
+ 	      
+ 	      "-thread", 
+ 	      Arg.Unit (fun _ -> threads := threads_default);
+@@ -1237,7 +1346,7 @@
+     with
+       any ->
+ 	close_out initl;
+-	Sys.remove initl_file_name;
++	remove_file initl_file_name;
+ 	raise any
+   end;
+ 
+@@ -1245,9 +1354,9 @@
+     at_exit
+       (fun () ->
+ 	let tr f x = try f x with _ -> () in
+-	tr Sys.remove initl_file_name;
+-	tr Sys.remove (Filename.chop_extension initl_file_name ^ ".cmi");
+-	tr Sys.remove (Filename.chop_extension initl_file_name ^ ".cmo");
++	tr remove_file initl_file_name;
++	tr remove_file (Filename.chop_extension initl_file_name ^ ".cmi");
++	tr remove_file (Filename.chop_extension initl_file_name ^ ".cmo");
+       );
+ 
+   let exclude_list = [ stdlibdir; threads_dir; vmthreads_dir ] in
+@@ -1493,7 +1602,9 @@
+ 	  [ "-v", Arg.Unit (fun () -> verbose := Verbose);
+ 	    "-pp", Arg.String (fun s ->
+ 				 pp_specified := true;
+-				 options := !options @ ["-pp"; s]);
++				 options := !options @ ["-pp"; rewrite_pp s]);
++            "-ppx", Arg.String (fun s ->
++				 options := !options @ ["-ppx"; rewrite_pp s]);
+ 	  ]
+       )
+     )
+@@ -1672,7 +1783,9 @@
+ 	      Arg.String (fun s -> add_spec_fn "-I" (slashify (resolve_path s)));
+ 
+ 	      "-pp", Arg.String (fun s -> pp_specified := true;
+-		 	           add_spec_fn "-pp" s);
++                           add_spec_fn "-pp" (rewrite_pp s));
++              "-ppx", Arg.String (fun s -> add_spec_fn "-ppx" (rewrite_pp s));
++
+ 	    ]
+ 	)
+     )
+@@ -1830,7 +1943,10 @@
+       output_string ch_out append;
+       close_out ch_out;
+       close_in ch_in;
+-      Unix.utimes outpath s.Unix.st_mtime s.Unix.st_mtime;
++      (try Unix.utimes outpath s.Unix.st_mtime s.Unix.st_mtime
++       with Unix.Unix_error(e,_,_) ->
++         prerr_endline("Warning: setting utimes for " ^ outpath
++                       ^ ": " ^ Unix.error_message e));
+ 
+       prerr_endline("Installed " ^ outpath);
+     with
+@@ -1882,6 +1998,8 @@
+              Unix.openfile (Filename.concat dir owner_file) [Unix.O_RDONLY] 0 in
+            let f =
+              Unix.in_channel_of_descr fd in
++           if is_win then
++             set_binary_mode_in f false;
+            try
+              let line = input_line f in
+              let is_my_file = (line = pkg) in
+@@ -2208,7 +2326,7 @@
+     let lines = read_ldconf !ldconf in
+     let dlldir_norm = Fl_split.norm_dir dlldir in
+     let dlldir_norm_lc = string_lowercase_ascii dlldir_norm in
+-    let ci_filesys = (Sys.os_type = "Win32") in
++    let ci_filesys = is_win in
+     let check_dir d =
+       let d' = Fl_split.norm_dir d in
+       (d' = dlldir_norm) || 
+@@ -2356,7 +2474,7 @@
+       List.iter
+         (fun file ->
+            let absfile = Filename.concat dlldir file in
+-           Sys.remove absfile;
++           remove_file absfile;
+            prerr_endline ("Removed " ^ absfile)
+         )
+         dll_files
+@@ -2365,7 +2483,7 @@
+     (* Remove the files from the package directory: *)
+     if Sys.file_exists pkgdir then begin
+       let files = Sys.readdir pkgdir in
+-      Array.iter (fun f -> Sys.remove (Filename.concat pkgdir f)) files;
++      Array.iter (fun f -> remove_file (Filename.concat pkgdir f)) files;
+       Unix.rmdir pkgdir;
+       prerr_endline ("Removed " ^ pkgdir)
+     end
+@@ -2415,7 +2533,9 @@
+ 
+ 
+ let print_configuration() =
++  let sl = slashify in
+   let dir s =
++    let s = sl s in
+     if Sys.file_exists s then
+       s
+     else
+@@ -2453,27 +2573,27 @@
+ 	   if md = "" then "the corresponding package directories" else dir md
+ 	  );
+ 	Printf.printf "The standard library is assumed to reside in:\n    %s\n"
+-	  (Findlib.ocaml_stdlib());
++    (sl (Findlib.ocaml_stdlib()));
+ 	Printf.printf "The ld.conf file can be found here:\n    %s\n"
+-	  (Findlib.ocaml_ldconf());
++    (sl (Findlib.ocaml_ldconf()));
+ 	flush stdout
+     | Some "conf" ->
+-	print_endline Findlib_config.config_file
++  print_endline (sl Findlib_config.config_file)
+     | Some "path" ->
+-	List.iter print_endline (Findlib.search_path())
++  List.iter ( fun x -> print_endline (sl x)) (Findlib.search_path())
+     | Some "destdir" ->
+-	print_endline (Findlib.default_location())
++  print_endline ( sl (Findlib.default_location()))
+     | Some "metadir" ->
+-	print_endline (Findlib.meta_directory())
++  print_endline ( sl (Findlib.meta_directory()))
+     | Some "metapath" ->
+         let mdir = Findlib.meta_directory() in
+         let ddir = Findlib.default_location() in
+-	print_endline 
+-          (if mdir <> "" then mdir ^ "/META.%s" else ddir ^ "/%s/META")
++  print_endline ( sl
++          (if mdir <> "" then mdir ^ "/META.%s" else ddir ^ "/%s/META"))
+     | Some "stdlib" ->
+-	print_endline (Findlib.ocaml_stdlib())
++  print_endline ( sl (Findlib.ocaml_stdlib()))
+     | Some "ldconf" ->
+-	print_endline (Findlib.ocaml_ldconf())
++  print_endline ( sl (Findlib.ocaml_ldconf()))
+     | _ ->
+ 	assert false
+ ;;
+@@ -2481,7 +2601,7 @@
+ 
+ let ocamlcall pkg cmd =
+   let dir = package_directory pkg in
+-  let path = Filename.concat dir cmd in
++  let path = rewrite_cmd (Filename.concat dir cmd) in
+   begin
+     try Unix.access path [ Unix.X_OK ]
+     with
+@@ -2647,6 +2767,10 @@
+   | Sys_error f ->
+       prerr_endline ("ocamlfind: " ^ f);
+       exit 2
++  | Unix.Unix_error (e, fn, f) ->
++      prerr_endline ("ocamlfind: " ^ fn ^ " " ^ f
++                     ^ ": " ^ Unix.error_message e);
++      exit 2
+   | Findlib.No_such_package(pkg,info) ->
+       prerr_endline ("ocamlfind: Package `" ^ pkg ^ "' not found" ^
+ 		     (if info <> "" then " - " ^ info else ""));
+--- ./src/findlib/Makefile
++++ ./src/findlib/Makefile
+@@ -90,6 +90,7 @@
+ 	cat findlib_config.mlp | \
+ 	        $(SH) $(TOP)/tools/patch '@CONFIGFILE@' '$(OCAMLFIND_CONF)' | \
+ 	        $(SH) $(TOP)/tools/patch '@STDLIB@' '$(OCAML_CORE_STDLIB)' | \
++			$(SH) $(TOP)/tools/patch '@EXEC_SUFFIX@' '$(EXEC_SUFFIX)' | \
+ 		sed -e 's;@AUTOLINK@;$(OCAML_AUTOLINK);g' \
+ 		    -e 's;@SYSTEM@;$(SYSTEM);g' \
+ 		     >findlib_config.ml
+@@ -113,7 +114,7 @@
+ 	$(OCAMLC) -a -o num_top.cma $(NUMTOP_OBJECTS)
+ 
+ clean:
+-	rm -f *.cmi *.cmo *.cma *.cmx *.a *.o *.cmxa \
++	rm -f *.cmi *.cmo *.cma *.cmx *.lib *.a *.o *.cmxa \
+ 	  fl_meta.ml findlib_config.ml findlib.mml topfind.ml topfind \
+ 	  ocamlfind$(EXEC_SUFFIX) ocamlfind_opt$(EXEC_SUFFIX)
+ 
+@@ -121,7 +122,7 @@
+ 	mkdir -p "$(prefix)$(OCAML_SITELIB)/$(NAME)"
+ 	mkdir -p "$(prefix)$(OCAMLFIND_BIN)"
+ 	test $(INSTALL_TOPFIND) -eq 0 || cp topfind "$(prefix)$(OCAML_CORE_STDLIB)"
+-	files=`$(SH) $(TOP)/tools/collect_files $(TOP)/Makefile.config findlib.cmi findlib.mli findlib.cma findlib.cmxa findlib.a findlib.cmxs topfind.cmi topfind.mli fl_package_base.mli fl_package_base.cmi fl_metascanner.mli fl_metascanner.cmi fl_metatoken.cmi findlib_top.cma findlib_top.cmxa findlib_top.a findlib_top.cmxs findlib_dynload.cma findlib_dynload.cmxa findlib_dynload.a findlib_dynload.cmxs fl_dynload.mli fl_dynload.cmi META` && \
++	files=`$(SH) $(TOP)/tools/collect_files $(TOP)/Makefile.config findlib.cmi findlib.mli findlib.cma findlib.cmxa findlib$(LIB_SUFFIX) findlib.cmxs topfind.cmi topfind.mli fl_package_base.mli fl_package_base.cmi fl_metascanner.mli fl_metascanner.cmi fl_metatoken.cmi findlib_top.cma findlib_top.cmxa findlib_top$(LIB_SUFFIX) findlib_top.cmxs findlib_dynload.cma findlib_dynload.cmxa findlib_dynload$(LIB_SUFFIX) findlib_dynload.cmxs fl_dynload.mli fl_dynload.cmi META` && \
+ 	cp $$files "$(prefix)$(OCAML_SITELIB)/$(NAME)"
+ 	f="ocamlfind$(EXEC_SUFFIX)"; { test -f ocamlfind_opt$(EXEC_SUFFIX) && f="ocamlfind_opt$(EXEC_SUFFIX)"; }; \
+ 	cp $$f "$(prefix)$(OCAMLFIND_BIN)/ocamlfind$(EXEC_SUFFIX)"

--- a/esy.lock/opam-override/ocamlfind.1.8.0/package.json
+++ b/esy.lock/opam-override/ocamlfind.1.8.0/package.json
@@ -1,0 +1,29 @@
+{
+  "override": {
+    "build": [
+      [
+        "bash", "-c",
+        "#{os == 'windows' ? 'patch -p1 < findlib-1.8.0.patch' : 'true'}"
+      ],
+      [
+        "./configure", "-bindir", "#{self.bin}", "-sitelib", "#{self.lib}",
+        "-mandir", "#{self.man}", "-config", "#{self.lib}/findlib.conf",
+        "-no-custom", "-no-topfind"
+      ],
+      [ "make", "all" ],
+      [ "make", "opt" ]
+    ],
+    "install": [
+      [ "make", "install" ],
+      [ "install", "-m", "0755", "ocaml-stub", "#{self.bin}/ocaml" ],
+      [ "mkdir", "-p", "#{self.toplevel}" ],
+      [
+        "install", "-m", "0644", "src/findlib/topfind",
+        "#{self.toplevel}/topfind"
+      ]
+    ],
+    "exportedEnv": {
+      "OCAML_TOPLEVEL_PATH": { "val": "#{self.toplevel}", "scope": "global" }
+    }
+  }
+}

--- a/esy.lock/opam/base-bytes.base/opam
+++ b/esy.lock/opam/base-bytes.base/opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+maintainer: " "
+authors: " "
+homepage: " "
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "ocamlfind" {>= "1.5.3"}
+]
+synopsis: "Bytes library distributed with the OCaml compiler"

--- a/esy.lock/opam/base-threads.base/opam
+++ b/esy.lock/opam/base-threads.base/opam
@@ -1,0 +1,6 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+description: """
+Threads library distributed with the OCaml compiler
+"""
+

--- a/esy.lock/opam/base-unix.base/opam
+++ b/esy.lock/opam/base-unix.base/opam
@@ -1,0 +1,6 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+description: """
+Unix library distributed with the OCaml compiler
+"""
+

--- a/esy.lock/opam/biniou.1.2.0/opam
+++ b/esy.lock/opam/biniou.1.2.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "martin@mjambon.com"
+authors: ["Martin Jambon"]
+
+homepage: "https://github.com/mjambon/biniou"
+bug-reports: "https://github.com/mjambon/biniou/issues"
+dev-repo: "git+https://github.com/mjambon/biniou.git"
+license: "BSD-3-Clause"
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "conf-which" {build}
+  "jbuilder" {build & >= "1.0+beta7"}
+  "easy-format"
+]
+synopsis:
+  "Binary data format designed for speed, safety, ease of use and backward compatibility as protocols evolve"
+url {
+  src: "https://github.com/mjambon/biniou/archive/v1.2.0.tar.gz"
+  checksum: "md5=f3e92358e832ed94eaf23ce622ccc2f9"
+}

--- a/esy.lock/opam/camomile.1.0.1/opam
+++ b/esy.lock/opam/camomile.1.0.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "yoriyuki.y@gmail.com"
+authors: ["Yoriyuki Yamagata"]
+homepage: "https://github.com/yoriyuki/Camomile/wiki"
+bug-reports: "https://github.com/yoriyuki/Camomile/issues"
+license: "LGPL-2+ with OCaml linking exception"
+dev-repo: "git+https://github.com/yoriyuki/Camomile.git"
+build: [
+  ["ocaml" "configure.ml" "--share" "%{share}%/camomile"]
+  ["jbuilder" "subst" "-p" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "jbuilder" {build & >= "1.0+beta17"}
+]
+synopsis: "A Unicode library"
+description: """
+Camomile is a Unicode library for OCaml. Camomile provides Unicode character
+type, UTF-8, UTF-16, UTF-32 strings, conversion to/from about 200 encodings,
+collation and locale-sensitive case mappings, and more. The library is currently
+designed for Unicode Standard 3.2."""
+url {
+  src:
+    "https://github.com/yoriyuki/Camomile/releases/download/1.0.1/camomile-1.0.1.tbz"
+  checksum: "md5=82e016653431353a07f22c259adc6e05"
+}

--- a/esy.lock/opam/chalk.1.0/opam
+++ b/esy.lock/opam/chalk.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Nick Zuber <zuber.nicholas@gmail.com>"
+authors: "Nick Zuber <zuber.nicholas@gmail.com>"
+homepage: "https://github.com/nickzuber/chalk"
+bug-reports: "https://github.com/nickzuber/chalk/issues"
+license: "MIT"
+dev-repo: "git+ssh://git@github.com/nickzuber/chalk.git"
+build: [make "build"]
+install: [make "build"]
+remove: ["ocamlfind" "remove" "chalk"]
+depends: ["ocaml" "ocamlfind"]
+synopsis: "Composable and simple terminal highlighting package"
+description: """
+Composable and simple terminal highlighting package. Very simple API;
+and example usage could be as follows:
+
+```ocaml
+let some_string = "Hello world!"
+  |> Chalk.red
+  |> Chalk.bold
+  |> Chalk.underline
+```"""
+flags: light-uninstall
+url {
+  src: "https://github.com/nickzuber/chalk/archive/v1.0.tar.gz"
+  checksum: "md5=c685f3024e5a4e74c86b4d9ce67ae34f"
+}

--- a/esy.lock/opam/cmdliner.1.0.2/opam
+++ b/esy.lock/opam/cmdliner.1.0.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/cmdliner"
+doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
+dev-repo: "git+http://erratique.ch/repos/cmdliner.git"
+bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
+tags: [ "cli" "system" "declarative" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "result"
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+]]
+synopsis: "Declarative definition of command line interfaces for OCaml"
+description: """
+Cmdliner allows the declarative definition of command line interfaces
+for OCaml.
+
+It provides a simple and compositional mechanism to convert command
+line arguments to OCaml values and pass them to your functions. The
+module automatically handles syntax errors, help messages and UNIX man
+page generation. It supports programs with single or multiple commands
+and respects most of the [POSIX][1] and [GNU][2] conventions.
+
+Cmdliner has no dependencies and is distributed under the ISC license.
+
+[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
+[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html"""
+url {
+  src: "http://erratique.ch/software/cmdliner/releases/cmdliner-1.0.2.tbz"
+  checksum: "md5=ab2f0130e88e8dcd723ac6154c98a881"
+}

--- a/esy.lock/opam/conf-m4.1/opam
+++ b/esy.lock/opam/conf-m4.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "tim@gfxmonk.net"
+homepage: "http://www.gnu.org/software/m4/m4.html"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "GNU Project"
+license: "GPL-3"
+build: [["sh" "-exc" "echo | m4"]]
+depexts: [
+  ["m4"] {os-distribution = "debian"}
+  ["m4"] {os-distribution = "ubuntu"}
+  ["m4"] {os-distribution = "fedora"}
+  ["m4"] {os-distribution = "rhel"}
+  ["m4"] {os-distribution = "centos"}
+  ["m4"] {os-distribution = "alpine"}
+  ["m4"] {os-distribution = "nixos"}
+  ["m4"] {os-distribution = "opensuse"}
+  ["m4"] {os-distribution = "oraclelinux"}
+  ["m4"] {os-distribution = "archlinux"}
+]
+synopsis: "Virtual package relying on m4"
+description:
+  "This package can only install if the m4 binary is installed on the system."
+flags: conf

--- a/esy.lock/opam/conf-which.1/opam
+++ b/esy.lock/opam/conf-which.1/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+homepage: "http://www.gnu.org/software/which/"
+authors: "Carlo Wood"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-2+"
+build: [["which" "which"]]
+depexts: [
+  ["which"] {os-distribution = "centos"}
+  ["which"] {os-distribution = "fedora"}
+  ["which"] {os-distribution = "opensuse"}
+  ["debianutils"] {os-distribution = "debian"}
+  ["debianutils"] {os-distribution = "ubuntu"}
+  ["which"] {os-distribution = "nixos"}
+  ["which"] {os-distribution = "archlinux"}
+]
+synopsis: "Virtual package relying on which"
+description:
+  "This package can only install if the which program is installed on the system."
+flags: conf

--- a/esy.lock/opam/cppo.1.6.5/opam
+++ b/esy.lock/opam/cppo.1.6.5/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "martin@mjambon.com"
+authors: ["Martin Jambon"]
+homepage: "https://github.com/mjambon/cppo"
+dev-repo: "git+https://github.com/mjambon/cppo.git"
+bug-reports: "https://github.com/mjambon/cppo/issues"
+license: "BSD-3-Clause"
+
+build: [
+  ["jbuilder" "subst" "-p" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml"
+  "jbuilder" {build & >= "1.0+beta17"}
+  "base-unix"
+]
+synopsis: "Equivalent of the C preprocessor for OCaml programs"
+url {
+  src: "https://github.com/mjambon/cppo/archive/v1.6.5.tar.gz"
+  checksum: "md5=1cd25741d31417995b0973fe0b6f6c82"
+}

--- a/esy.lock/opam/dune.1.6.0/opam
+++ b/esy.lock/opam/dune.1.6.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+dev-repo: "git+https://github.com/ocaml/dune.git"
+license: "MIT"
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-unix"
+  "base-threads"
+]
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml"]
+  ["./boot.exe" "--release" "--subst"] {pinned}
+  ["./boot.exe" "--release" "-j" jobs]
+]
+conflicts: [
+  "jbuilder" {!= "transition"}
+  "odoc" {< "1.3.0"}
+]
+
+synopsis: "Fast, portable and opinionated build system"
+description: """
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, it has very low-overhead and support parallel builds on
+all platforms. It has no system dependencies, all you need to build
+dune and packages using dune is OCaml. You don't need or make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+url {
+  src: "https://github.com/ocaml/dune/releases/download/1.6.0/dune-1.6.0.tbz"
+  checksum: "md5=ac99a0ece781c84117772219f5a39007"
+}

--- a/esy.lock/opam/easy-format.1.3.1/opam
+++ b/esy.lock/opam/easy-format.1.3.1/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "martin@mjambon.com"
+authors: ["Martin Jambon"]
+homepage: "http://mjambon.com/easy-format.html"
+bug-reports: "https://github.com/mjambon/easy-format/issues"
+dev-repo: "git+https://github.com/mjambon/easy-format.git"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "jbuilder" {build}
+]
+synopsis:
+  "High-level and functional interface to the Format module of the OCaml standard library"
+url {
+  src: "https://github.com/mjambon/easy-format/archive/v1.3.1.tar.gz"
+  checksum: "md5=4e163700fb88fdcd6b8976c3a216c8ea"
+}

--- a/esy.lock/opam/jbuilder.transition/opam
+++ b/esy.lock/opam/jbuilder.transition/opam
@@ -1,0 +1,15 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+dev-repo: "git+https://github.com/ocaml/dune.git"
+license: "MIT"
+depends: ["ocaml" "dune"]
+post-messages: [
+  "Jbuilder has been renamed and the jbuilder package is now a transition \
+   package. Use the dune package instead."
+]
+synopsis:
+  "This is a transition package, jbuilder is now named dune. Use the dune"
+description: "package instead."

--- a/esy.lock/opam/js_of_ocaml-compiler.3.2.1/opam
+++ b/esy.lock/opam/js_of_ocaml-compiler.3.2.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.org/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+
+name: "js_of_ocaml-compiler"
+
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "jbuilder" {build & >= "1.0+beta17"}
+  "cmdliner"
+  "cppo" {>= "1.1.0"}
+  "ocamlfind"
+  "yojson"
+]
+conflicts: [
+  "ocamlfind"   {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+
+synopsis: "Compiler from OCaml bytecode to Javascript"
+url {
+  src: "https://github.com/ocsigen/js_of_ocaml/archive/3.2.1.tar.gz"
+  checksum: "md5=5ebfb1bf85dc90e45e0f7ca71a9053b4"
+}

--- a/esy.lock/opam/js_of_ocaml-lwt.3.2.1/opam
+++ b/esy.lock/opam/js_of_ocaml-lwt.3.2.1/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.org/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+
+name: "js_of_ocaml-lwt"
+
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "jbuilder" {build & >= "1.0+beta17"}
+  "lwt" {>= "2.4.4"}
+  "js_of_ocaml" {>= "3.2"}
+  "js_of_ocaml-ppx"
+]
+depopts: [ "graphics" "lwt_log" ]
+
+synopsis: "Compiler from OCaml bytecode to Javascript"
+url {
+  src: "https://github.com/ocsigen/js_of_ocaml/archive/3.2.1.tar.gz"
+  checksum: "md5=5ebfb1bf85dc90e45e0f7ca71a9053b4"
+}

--- a/esy.lock/opam/js_of_ocaml-ppx.3.2.0/opam
+++ b/esy.lock/opam/js_of_ocaml-ppx.3.2.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.org/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+
+name: "js_of_ocaml-ppx"
+
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "jbuilder" {build & >= "1.0+beta17"}
+  "ocaml-migrate-parsetree"
+  "ppx_tools_versioned"
+  "js_of_ocaml" {>= "3.0"}
+]
+conflicts: [
+  "ppx_tools_versioned"     {<="5.0beta0"}
+]
+
+synopsis: "Compiler from OCaml bytecode to Javascript"
+url {
+  src: "https://github.com/ocsigen/js_of_ocaml/archive/3.2.0.tar.gz"
+  checksum: "md5=5f7d6121f2b549b5ee83a625a142219b"
+}

--- a/esy.lock/opam/js_of_ocaml.3.2.0/opam
+++ b/esy.lock/opam/js_of_ocaml.3.2.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer:   "dev@ocsigen.org"
+authors:      "Ocsigen team"
+bug-reports:  "https://github.com/ocsigen/js_of_ocaml/issues"
+homepage:     "http://ocsigen.org/js_of_ocaml"
+dev-repo:     "git+https://github.com/ocsigen/js_of_ocaml.git"
+
+name: "js_of_ocaml"
+
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "jbuilder" {build & >= "1.0+beta17"}
+  "ocaml-migrate-parsetree"
+  "ppx_tools_versioned"
+  "uchar"
+  "js_of_ocaml-compiler"
+]
+conflicts: [
+  "ppx_tools_versioned"     {<= "5.0beta0"}
+]
+
+synopsis: "Compiler from OCaml bytecode to Javascript"
+url {
+  src: "https://github.com/ocsigen/js_of_ocaml/archive/3.2.0.tar.gz"
+  checksum: "md5=5f7d6121f2b549b5ee83a625a142219b"
+}

--- a/esy.lock/opam/lambda-term.1.13/opam
+++ b/esy.lock/opam/lambda-term.1.13/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "jeremie@dimino.org"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/diml/lambda-term"
+bug-reports: "https://github.com/diml/lambda-term/issues"
+dev-repo: "git://github.com/diml/lambda-term.git"
+license: "BSD3"
+build: [
+  ["jbuilder" "subst" "-p" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "lwt" {>= "2.7.0"}
+  "lwt_log"
+  "react"
+  "zed" {>= "1.2"}
+  "camomile" {>= "0.8.6"}
+  "lwt_react"
+  "jbuilder" {build & >= "1.0+beta9"}
+]
+synopsis: "Terminal manipulation library for OCaml"
+description: """
+Lambda-term is a cross-platform library for manipulating the terminal. It
+provides an abstraction for keys, mouse events, colors, as well as a set of
+widgets to write curses-like applications. The main objective of lambda-term is
+to provide a higher level functional interface to terminal manipulation than,
+for example, ncurses, by providing a native OCaml interface instead of bindings
+to a C library. Lambda-term integrates with zed to provide text edition
+facilities in console applications."""
+url {
+  src:
+    "https://github.com/diml/lambda-term/releases/download/1.13/lambda-term-1.13.tbz"
+  checksum: "md5=c13826a97014d4d573b927b623c7e043"
+}

--- a/esy.lock/opam/lwt.4.1.0/opam
+++ b/esy.lock/opam/lwt.4.1.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+version: "4.1.0"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Mauricio Fernandez <mfp@acm.org>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+]
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/manual/"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+build: [
+  [ "ocaml" "src/util/configure.ml" "-use-libev" "%{conf-libev:installed}%" ]
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "cppo" {build & >= "1.1.0"}
+  "jbuilder" {build & >= "1.0+beta14"}
+  "ocamlfind" {build & >= "1.7.3-1"}
+  "result"
+]
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+# In practice, Lwt requires OCaml >= 4.02.3, as that is a constraint of the
+# dependency jbuilder.
+messages: [
+  "For the PPX, please install package lwt_ppx"
+    {!lwt_ppx:installed}
+  "For the Camlp4 syntax, please install package lwt_camlp4"
+    {camlp4:installed & !lwt_camlp4:installed}
+  "For Lwt_log and Lwt_daemon, please install package lwt_log"
+    {!lwt_log:installed}
+]
+synopsis: "Promises, concurrency, and parallelized I/O"
+description: """
+A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis."""
+conflicts: [
+  "ocaml-variants" {= "4.02.1+BER"}
+]
+url {
+  src: "https://github.com/ocsigen/lwt/archive/4.1.0.tar.gz"
+  checksum: "md5=e919bee206f18b3d49250ecf9584fde7"
+}

--- a/esy.lock/opam/lwt_log.1.1.0/opam
+++ b/esy.lock/opam/lwt_log.1.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+version: "1.1.0"
+homepage: "https://github.com/aantron/lwt_log"
+doc: "https://github.com/aantron/lwt_log/blob/master/src/core/lwt_log_core.mli"
+bug-reports: "https://github.com/aantron/lwt_log/issues"
+license: "LGPL"
+
+authors: [
+  "Shawn Wagner"
+  "Jérémie Dimino"
+]
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/lwt_log.git"
+depends: [
+  "ocaml"
+  "jbuilder" {build & >= "1.0+beta10"}
+  "lwt" {>= "4.0.0"}
+]
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+synopsis: "Lwt logging library (deprecated)"
+url {
+  src: "https://github.com/aantron/lwt_log/archive/1.1.0.tar.gz"
+  checksum: "md5=92142135d01a4d7e805990cc98653d55"
+}

--- a/esy.lock/opam/lwt_ppx.1.2.1/opam
+++ b/esy.lock/opam/lwt_ppx.1.2.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+version: "1.2.1"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+authors: [
+  "Gabriel Radanne"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Ppx_lwt"
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "jbuilder" {build & >= "1.0+beta14"}
+  "lwt"
+  "ocaml-migrate-parsetree"
+  "ppx_tools_versioned" {>= "5.0.1"}
+]
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+synopsis:
+  "PPX syntax for Lwt, providing something similar to async/await from JavaScript"
+url {
+  src: "https://github.com/ocsigen/lwt/archive/4.1.0.tar.gz"
+  checksum: "md5=e919bee206f18b3d49250ecf9584fde7"
+}

--- a/esy.lock/opam/lwt_react.1.1.1/opam
+++ b/esy.lock/opam/lwt_react.1.1.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+version: "1.1.1"
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Mauricio Fernandez <mfp@acm.org>"
+  "Simon Cruanes <simon.cruanes.2007@m4x.org>"
+]
+authors: [
+  "Jérémie Dimino"
+]
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Lwt_react"
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+license: "LGPL with OpenSSL linking exception"
+
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml"
+  "jbuilder" {build & >= "1.0+beta14"}
+  "lwt" {>= "3.0.0"}
+  "react" {>= "1.0.0"}
+]
+synopsis: "Helpers for using React with Lwt"
+url {
+  src: "https://github.com/ocsigen/lwt/archive/4.0.0.tar.gz"
+  checksum: "md5=3bbde866884e32cc7a9d9cbd1e52bde3"
+}

--- a/esy.lock/opam/menhir.20171013/opam
+++ b/esy.lock/opam/menhir.20171013/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+  "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
+]
+homepage: "http://gallium.inria.fr/~fpottier/menhir/"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+bug-reports: "menhir@inria.fr"
+build: [
+  [make "-f" "Makefile" "PREFIX=%{prefix}%" "USE_OCAMLFIND=true" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
+]
+install: [
+  [make "-f" "Makefile" "install" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
+]
+remove: [
+  [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
+synopsis: "LR(1) parser generator"
+url {
+  src: "http://gallium.inria.fr/~fpottier/menhir/menhir-20171013.tar.gz"
+  checksum: "md5=620863edea40437390ee5e5bd82fba11"
+}

--- a/esy.lock/opam/merlin-extend.0.3/opam
+++ b/esy.lock/opam/merlin-extend.0.3/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/merlin-extend"
+bug-reports: "https://github.com/let-def/merlin-extend"
+license: "MIT"
+dev-repo: "git+https://github.com/let-def/merlin-extend.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "merlin_extend"]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "ocamlfind" {build}
+  "cppo" {build}
+]
+synopsis: "A protocol to provide custom frontend to Merlin"
+description: """
+This protocol allows to replace the OCaml frontend of Merlin.
+It extends what used to be done with the `-pp' flag to handle a few more cases."""
+flags: light-uninstall
+url {
+  src: "https://github.com/let-def/merlin-extend/archive/v0.3.tar.gz"
+  checksum: "md5=9c6dfd4f53328f02f12fcc265f4e2dda"
+}

--- a/esy.lock/opam/ocaml-migrate-parsetree.1.1.0/opam
+++ b/esy.lock/opam/ocaml-migrate-parsetree.1.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+license: "LGPL-2.1"
+homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
+doc: "https://ocaml-ppx.github.io/ocaml-migrate-parsetree/"
+tags: [ "syntax" "org:ocamllabs" ]
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "result"
+  "dune" {build}
+  "ocaml" {>= "4.02.0"}
+]
+
+description: """
+Convert OCaml parsetrees between different versions 
+
+This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
+High-level functions help making PPX rewriters independent of a compiler version.
+"""
+
+url {
+  src: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v1.1.0/ocaml-migrate-parsetree-1.1.0.tbz"
+  checksum: ["md5=7dd4808e27af98065f63604c9658d311"]
+}
+

--- a/esy.lock/opam/ocamlbuild.0.12.0/opam
+++ b/esy.lock/opam/ocamlbuild.0.12.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
+authors: ["Nicolas Pouillard" "Berke Durak"]
+homepage: "https://github.com/ocaml/ocamlbuild/"
+bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
+license: "LGPL-2 with OCaml linking exception"
+doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
+dev-repo: "git+https://github.com/ocaml/ocamlbuild.git"
+build: [
+  [
+    make
+    "-f"
+    "configure.make"
+    "all"
+    "OCAMLBUILD_PREFIX=%{prefix}%"
+    "OCAMLBUILD_BINDIR=%{bin}%"
+    "OCAMLBUILD_LIBDIR=%{lib}%"
+    "OCAMLBUILD_MANDIR=%{man}%"
+    "OCAML_NATIVE=%{ocaml:native}%"
+    "OCAML_NATIVE_TOOLS=%{ocaml:native}%"
+  ]
+  [make "check-if-preinstalled" "all" "opam-install"]
+]
+conflicts: [
+  "base-ocamlbuild"
+  "ocamlfind" {< "1.6.2"}
+]
+synopsis:
+  "OCamlbuild is a build system with builtin rules to easily build most OCaml projects."
+depends: [
+  "ocaml" {>= "4.03" & < "4.08.0"}
+]
+url {
+  src: "https://github.com/ocaml/ocamlbuild/archive/0.12.0.tar.gz"
+  checksum: "md5=442baa19470bd49150f153122e22907b"
+}

--- a/esy.lock/opam/ocamlfind.1.8.0/files/ocaml-stub
+++ b/esy.lock/opam/ocamlfind.1.8.0/files/ocaml-stub
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+BINDIR=$(dirname "$(command -v ocamlc)")
+"$BINDIR/ocaml" -I "$OCAML_TOPLEVEL_PATH" "$@"

--- a/esy.lock/opam/ocamlfind.1.8.0/files/ocamlfind.install
+++ b/esy.lock/opam/ocamlfind.1.8.0/files/ocamlfind.install
@@ -1,0 +1,6 @@
+bin: [
+  "src/findlib/ocamlfind" {"ocamlfind"}
+  "?src/findlib/ocamlfind_opt" {"ocamlfind"}
+  "?tools/safe_camlp4"
+]
+toplevel: ["src/findlib/topfind"]

--- a/esy.lock/opam/ocamlfind.1.8.0/opam
+++ b/esy.lock/opam/ocamlfind.1.8.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+homepage:     "http://projects.camlcity.org/projects/findlib.html"
+bug-reports:  "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
+dev-repo: "git+https://gitlab.camlcity.org/gerd/lib-findlib.git"
+build: [
+  [
+    "./configure"
+    "-bindir"
+    bin
+    "-sitelib"
+    lib
+    "-mandir"
+    man
+    "-config"
+    "%{lib}%/findlib.conf"
+    "-no-custom"
+    "-no-topfind" {ocaml:preinstalled}
+  ]
+  [make "all"]
+  [make "opt"] {ocaml:native}
+]
+install: [
+  [make "install"]
+  ["install" "-m" "0755" "ocaml-stub" "%{bin}%/ocaml"] {ocaml:preinstalled}
+]
+remove: [
+  ["ocamlfind" "remove" "bytes"]
+  [
+    "./configure"
+    "-bindir"
+    bin
+    "-sitelib"
+    lib
+    "-mandir"
+    man
+    "-config"
+    "%{lib}%/findlib.conf"
+    "-no-topfind" {ocaml:preinstalled}
+  ]
+  [make "uninstall"]
+  ["rm" "-f" "%{bin}%/ocaml"] {ocaml:preinstalled}
+]
+depends: [
+  "ocaml" {>= "4.00.0"}
+  "conf-m4" {build}
+]
+synopsis: "A library manager for OCaml"
+description: """
+Findlib is a library manager for OCaml. It provides a convention how
+to store libraries, and a file format ("META") to describe the
+properties of libraries. There is also a tool (ocamlfind) for
+interpreting the META files, so that it is very easy to use libraries
+in programs and scripts."""
+authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+extra-files: [
+  ["ocamlfind.install" "md5=06f2c282ab52d93aa6adeeadd82a2543"]
+  ["ocaml-stub" "md5=181f259c9e0bad9ef523e7d4abfdf87a"]
+]
+url {
+  src: "http://download.camlcity.org/download/findlib-1.8.0.tar.gz"
+  checksum: "md5=a710c559667672077a93d34eb6a42e5b"
+  mirrors: "http://download2.camlcity.org/download/findlib-1.8.0.tar.gz"
+}

--- a/esy.lock/opam/ppx_tools_versioned.5.2.1/opam
+++ b/esy.lock/opam/ppx_tools_versioned.5.2.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Alain Frisch <alain.frisch@lexifi.com>"
+]
+license: "MIT"
+homepage: "https://github.com/let-def/ppx_tools_versioned"
+bug-reports: "https://github.com/let-def/ppx_tools_versioned/issues"
+dev-repo: "git://github.com/let-def/ppx_tools_versioned.git"
+tags: [ "syntax" ]
+build: [
+  ["jbuilder" "subst" "-p" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "jbuilder" {build & >= "1.0+beta17"}
+  "ocaml-migrate-parsetree" {>= "1.0.10"}
+]
+synopsis: "A variant of ppx_tools based on ocaml-migrate-parsetree"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_tools_versioned/archive/5.2.1.tar.gz"
+  checksum: "md5=1ae6ae43ec161fbbf12c2b4d3a7e26f5"
+}

--- a/esy.lock/opam/re.1.8.0/opam
+++ b/esy.lock/opam/re.1.8.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "rudi.grinberg@gmail.com"
+authors: [
+  "Jerome Vouillon"
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Rudi Grinberg"
+  "Gabriel Radanne"
+]
+license: "LGPL-2.0 with OCaml linking exception"
+homepage: "https://github.com/ocaml/ocaml-re"
+bug-reports: "https://github.com/ocaml/ocaml-re/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml-re.git"
+build: [
+  ["jbuilder" "subst" "-n" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "jbuilder" {build & >= "1.0+beta10"}
+  "ounit" {with-test}
+  "seq"
+]
+synopsis: "RE is a regular expression library for OCaml"
+description: """
+Pure OCaml regular expressions with:
+* Perl-style regular expressions (module Re.Perl)
+* Posix extended regular expressions (module Re.Posix)
+* Emacs-style regular expressions (module Re.Emacs)
+* Shell-style file globbing (module Re.Glob)
+* Compatibility layer for OCaml's built-in Str module (module Re.Str)"""
+url {
+  src:
+    "https://github.com/ocaml/ocaml-re/releases/download/1.8.0/re-1.8.0.tbz"
+  checksum: "md5=765f6f8d3e6ab200866e719ed7e5178d"
+}

--- a/esy.lock/opam/react.1.2.1/opam
+++ b/esy.lock/opam/react.1.2.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+homepage: "http://erratique.ch/software/react"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+doc: "http://erratique.ch/software/react/doc/React"
+dev-repo: "git+http://erratique.ch/repos/react.git"
+bug-reports: "https://github.com/dbuenzli/react/issues"
+tags: [ "reactive" "declarative" "signal" "event" "frp" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+]
+build:
+[[ "ocaml" "pkg/pkg.ml" "build"
+           "--dev-pkg" "%{pinned}%" ]]
+synopsis: "Declarative events and signals for OCaml"
+description: """
+Release %%VERSION%%
+
+React is an OCaml module for functional reactive programming (FRP). It
+provides support to program with time varying values : declarative
+events and signals. React doesn't define any primitive event or
+signal, it lets the client chooses the concrete timeline.
+
+React is made of a single, independent, module and distributed under
+the ISC license."""
+url {
+  src: "http://erratique.ch/software/react/releases/react-1.2.1.tbz"
+  checksum: "md5=ce1454438ce4e9d2931248d3abba1fcc"
+}

--- a/esy.lock/opam/result.1.3/opam
+++ b/esy.lock/opam/result.1.3/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/result"
+dev-repo: "git+https://github.com/janestreet/result.git"
+bug-reports: "https://github.com/janestreet/result/issues"
+license: "BSD3"
+build: [["jbuilder" "build" "-p" name "-j" jobs]]
+depends: [
+  "ocaml"
+  "jbuilder" {build & >= "1.0+beta11"}
+]
+synopsis: "Compatibility Result module"
+description: """
+Projects that want to use the new result type defined in OCaml >= 4.03
+while staying compatible with older version of OCaml should use the
+Result module defined in this library."""
+url {
+  src:
+    "https://github.com/janestreet/result/releases/download/1.3/result-1.3.tbz"
+  checksum: "md5=4beebefd41f7f899b6eeba7414e7ae01"
+}

--- a/esy.lock/opam/seq.0.1/opam
+++ b/esy.lock/opam/seq.0.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+authors: "Simon Cruanes"
+homepage: "https://github.com/c-cube/seq/"
+bug-reports: "https://github.com/c-cube/seq/issues"
+license: "GPL"
+tags: ["iterator" "seq" "pure" "list" "compatibility" "cascade"]
+dev-repo: "git+https://github.com/c-cube/seq.git"
+build: [make "build"]
+install: [make "install"]
+remove: [ "ocamlfind" "remove" "seq" ]
+depends: [
+  "ocaml" {< "4.07.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+]
+synopsis:
+  "Compatibility package for OCaml's standard iterator type starting from 4.07."
+flags: light-uninstall
+url {
+  src: "https://github.com/c-cube/seq/archive/0.1.tar.gz"
+  checksum: "md5=0e87f9709541ed46ecb6f414bc31458c"
+}

--- a/esy.lock/opam/topkg.1.0.0/opam
+++ b/esy.lock/opam/topkg.1.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/topkg"
+doc: "http://erratique.ch/software/topkg/doc"
+license: "ISC"
+dev-repo: "git+http://erratique.ch/repos/topkg.git"
+bug-reports: "https://github.com/dbuenzli/topkg/issues"
+tags: ["packaging" "ocamlbuild" "org:erratique"]
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build & >= "1.6.1"}
+  "ocamlbuild"
+  "result" ]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pkg-name" name
+          "--dev-pkg" "%{pinned}%" ]]
+synopsis: """The transitory OCaml software packager"""
+description: """\
+
+Topkg is a packager for distributing OCaml software. It provides an
+API to describe the files a package installs in a given build
+configuration and to specify information about the package's
+distribution, creation and publication procedures.
+
+The optional topkg-care package provides the `topkg` command line tool
+which helps with various aspects of a package's life cycle: creating
+and linting a distribution, releasing it on the WWW, publish its
+documentation, add it to the OCaml opam repository, etc.
+
+Topkg is distributed under the ISC license and has **no**
+dependencies. This is what your packages will need as a *build*
+dependency.
+
+Topkg-care is distributed under the ISC license it depends on
+[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
+[webbrowser][webbrowser] and `opam-format`.
+
+[fmt]: http://erratique.ch/software/fmt
+[logs]: http://erratique.ch/software/logs
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner
+[webbrowser]: http://erratique.ch/software/webbrowser
+"""
+url {
+src: "http://erratique.ch/software/topkg/releases/topkg-1.0.0.tbz"
+checksum: "md5=e3d76bda06bf68cb5853caf6627da603"
+}

--- a/esy.lock/opam/uchar.0.0.2/opam
+++ b/esy.lock/opam/uchar.0.0.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://ocaml.org"
+doc: "https://ocaml.github.io/uchar/"
+dev-repo: "git+https://github.com/ocaml/uchar.git"
+bug-reports: "https://github.com/ocaml/uchar/issues"
+tags: [ "text" "character" "unicode" "compatibility" "org:ocaml.org" ]
+license: "typeof OCaml system"
+depends: [
+  "ocaml" {>= "3.12.0"}
+  "ocamlbuild" {build}
+]
+build: [
+  ["ocaml" "pkg/git.ml"]
+  [
+    "ocaml"
+    "pkg/build.ml"
+    "native=%{ocaml:native}%"
+    "native-dynlink=%{ocaml:native-dynlink}%"
+  ]
+]
+synopsis: "Compatibility library for OCaml's Uchar module"
+description: """
+The `uchar` package provides a compatibility library for the
+[`Uchar`][1] module introduced in OCaml 4.03.
+
+The `uchar` package is distributed under the license of the OCaml
+compiler. See [LICENSE](LICENSE) for details.
+
+[1]: http://caml.inria.fr/pub/docs/manual-ocaml/libref/Uchar.html"""
+url {
+  src:
+    "https://github.com/ocaml/uchar/releases/download/v0.0.2/uchar-0.0.2.tbz"
+  checksum: "md5=c9ba2c738d264c420c642f7bb1cf4a36"
+}

--- a/esy.lock/opam/yojson.1.4.1/opam
+++ b/esy.lock/opam/yojson.1.4.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "martin@mjambon.com"
+authors: ["Martin Jambon"]
+homepage: "http://mjambon.com/yojson.html"
+bug-reports: "https://github.com/mjambon/yojson/issues"
+dev-repo: "git+https://github.com/mjambon/yojson.git"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "jbuilder" {build}
+  "cppo" {build}
+  "easy-format"
+  "biniou" {>= "1.2.0"}
+]
+synopsis:
+  "Yojson is an optimized parsing and printing library for the JSON format"
+description: """
+It addresses a few shortcomings of json-wheel including 2x speedup,
+polymorphic variants and optional syntax for tuples and variants.
+
+ydump is a pretty-printing command-line program provided with the
+yojson package.
+
+The program atdgen can be used to derive OCaml-JSON serializers and
+deserializers from type definitions."""
+url {
+  src: "https://github.com/mjambon/yojson/archive/v1.4.1.tar.gz"
+  checksum: "md5=3ea6e36422dd670e8ab880710d5f7398"
+}

--- a/esy.lock/opam/zed.1.6/opam
+++ b/esy.lock/opam/zed.1.6/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/diml/zed"
+bug-reports: "https://github.com/diml/zed/issues"
+dev-repo: "git://github.com/diml/zed.git"
+license: "BSD3"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "jbuilder" {build & >= "1.0+beta9"}
+  "base-bytes"
+  "camomile" {>= "0.8"}
+  "react"
+]
+build: [
+  ["jbuilder" "subst" "-p" name] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Abstract engine for text edition in OCaml"
+description: """
+Zed is an abstract engine for text edition. It can be used to write text
+editors, edition widgets, readlines, ... Zed uses Camomile to fully support the
+Unicode specification, and implements an UTF-8 encoded string type with
+validation, and a rope datastructure to achieve efficient operations on large
+Unicode buffers. Zed also features a regular expression search on ropes. To
+support efficient text edition capabilities, Zed provides macro recording and
+cursor management facilities."""
+url {
+  src: "https://github.com/diml/zed/releases/download/1.6/zed-1.6.tbz"
+  checksum: "md5=f75c3094af1a22f9801d5ca5eb2d40e0"
+}


### PR DESCRIPTION
I'm using esy nightly build (`0.4.4-e128a`) and noticed the files in `esy.lock` weren't being tracked. Side note: it's the first time I see `esy.lock` as a folder, but considering the default `.gitignore` it includes, it seems it's expected to be tracked by git.

Also, `_build/` was previously in `.gitignore` and this PR adds `_esy/`.