### PR TITLE
Remove buildsInSource

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "test:js": "node _build/default/test/Test.bc.js"
   },
   "esy": {
-    "build": "refmterr dune build -p reactify",
-    "buildsInSource": "_build"
+    "build": "refmterr dune build -p reactify"
   },
   "dependencies": {
     "@opam/dune": "*",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:js": "esy b dune build test/Test.bc.js",
     "build:dom": "esy b refmterr dune build ./examples/dom/WebReconciler.bc.js",
     "test:native": "esy b dune runtest",
-    "test:js": "node _build/default/test/Test.bc.js"
+    "test:js": "node #{self.target_dir}/default/test/Test.bc.js"
   },
   "esy": {
     "build": "refmterr dune build -p reactify"


### PR DESCRIPTION
This is more of a question than anything else 😄 

I've noticed this repo and others use `buildsInSource` in the `esy` config. I wonder why this is needed? Is it for CI, or better Windows support?

What drove me to ask is that this configuration breaks `reason-language-server` –in macOS at least–, see https://github.com/jaredly/reason-language-server/issues/209. So I wondered about whether it could be removed.

If not, I can always keep working with this option disabled while developing, until a fix in RLS lands. :) 