### PR TITLE
Flatten component type

### DIFF
--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -40,7 +40,7 @@ module type React = {
     | Provider(render)
     | Empty(render)
   and componentFunction = unit => component
-  and childComponents = list(component)
+  and childComponents = list(component);
 
   type t;
 

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -30,31 +30,17 @@ module type React = {
   type primitives;
   type node;
 
-  type element =
-    | Primitive(primitives)
-    | Component(ComponentId.t)
-    | Provider
-    | Empty
-  and renderedElement =
+  type renderedElement =
     | RenderedPrimitive(node)
-  and elementWithChildren = (
-    element,
-    childComponents,
-    Effects.effects,
-    Context.t,
-  )
-  /*
-     A component is our JSX primitive element - just an object
-     with a render method.
-     TODO: Can we clean this interface up and just make component
-     a function of type unit => elementWithChildren ?
-   */
-  and component = {
-    element,
-    render: unit => elementWithChildren,
-  }
+  and elementWithChildren = (childComponents, Effects.effects, Context.t)
+  and render = unit => elementWithChildren
+  and component =
+    | Primitive(primitives, render)
+    | Component(ComponentId.t, render)
+    | Provider(render)
+    | Empty(render)
   and componentFunction = unit => component
-  and childComponents = list(component);
+  and childComponents = list(component)
 
   type t;
 


### PR DESCRIPTION
A small proposal to flatten the internal type for `component`.

Instead of keeping a record with `{element, render}` the PR implements `component` as a variant type where each constructor has the `render` function + optional id (for `Component`) or `primitives` (for `Primitive`).

This flattening allows to remove the first item `element` from the `elementWithChildren` tuple, leading to less duplicity.

The main downside is that in order to extract the `render` function we have to do pattern matching. That only happens once so the matching has been inlined, but it could be added to a function if needed.

These changes are only internal and don't break anything in the consumers / public API.