### PR TITLE
Encode "Rules of Hooks" in the API / type system. Rule 1 of 2: "Only Call Hooks at the Top Level"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## Next release
+
+## 3.0.0
+
+- Continuation-passing style API for hooks: [43](https://github.com/revery-ui/reason-reactify/pull/43/)
+
+## 2.0.0
+
+- First-class modules for components: [28](https://github.com/revery-ui/reason-reactify/pull/28/)

--- a/examples/dom/WebReconciler.re
+++ b/examples/dom/WebReconciler.re
@@ -163,7 +163,9 @@ let renderCounter = () => {
 };
 
 module CounterButtons = (
-  val createComponent((render, ~children, ()) => render(renderCounter, ~children))
+  val createComponent((render, ~children, ()) =>
+        render(renderCounter, ~children)
+      )
 );
 
 /* Create a container for our UI */

--- a/examples/dom/WebReconciler.re
+++ b/examples/dom/WebReconciler.re
@@ -153,7 +153,7 @@ let reducer = (state, action) =>
   };
 
 let renderCounter = () =>
-  useReducer(reducer, 0, (count, dispatch) =>
+  useReducer(reducer, 0, ((count, dispatch)) =>
     <view>
       <button title="Decrement" onPress={() => dispatch(Decrement)} />
       <text> {"Counter: " ++ str(count)} </text>

--- a/examples/dom/WebReconciler.re
+++ b/examples/dom/WebReconciler.re
@@ -163,7 +163,7 @@ let renderCounter = () => {
 };
 
 module CounterButtons = (
-  val component((render, ~children, ()) => render(renderCounter, ~children))
+  val createComponent((render, ~children, ()) => render(renderCounter, ~children))
 );
 
 /* Create a container for our UI */

--- a/examples/dom/WebReconciler.re
+++ b/examples/dom/WebReconciler.re
@@ -152,15 +152,14 @@ let reducer = (state, action) =>
   | Decrement => state - 1
   };
 
-let renderCounter = () => {
-  let (count, dispatch) = useReducer(reducer, 0);
-
-  <view>
-    <button title="Decrement" onPress={() => dispatch(Decrement)} />
-    <text> {"Counter: " ++ str(count)} </text>
-    <button title="Increment" onPress={() => dispatch(Increment)} />
-  </view>;
-};
+let renderCounter = () =>
+  useReducer(reducer, 0, (count, dispatch) =>
+    <view>
+      <button title="Decrement" onPress={() => dispatch(Decrement)} />
+      <text> {"Counter: " ++ str(count)} </text>
+      <button title="Increment" onPress={() => dispatch(Increment)} />
+    </view>
+  );
 
 module CounterButtons = (
   val createComponent((render, ~children, ()) =>

--- a/examples/lambda-term/Lambda_term.re
+++ b/examples/lambda-term/Lambda_term.re
@@ -141,7 +141,7 @@ let renderCounter = () => {
 };
 
 module CounterButtons = (
-  val component((render, ~children, ()) => render(renderCounter, ~children))
+  val createComponent((render, ~children, ()) => render(renderCounter, ~children))
 );
 /*
     Clock
@@ -150,7 +150,7 @@ module CounterButtons = (
     use of `useEffect` and `setState` together.
  */
 module Clock = (
-  val component((render, ~children, ()) =>
+  val createComponent((render, ~children, ()) =>
         render(
           () =>
             useState(

--- a/examples/lambda-term/Lambda_term.re
+++ b/examples/lambda-term/Lambda_term.re
@@ -152,17 +152,19 @@ module CounterButtons = (
 module Clock = (
   val component((render, ~children, ()) =>
         render(
-          () => {
-            let (time, setTime) = useState(0.);
-            useEffect(() => {
-              let evt =
-                Lwt_engine.on_timer(1.0, true, _ => setTime(Unix.time()));
+          () =>
+            useState(
+              0.,
+              (time, setTime) => {
+                useEffect(() => {
+                  let evt =
+                    Lwt_engine.on_timer(1.0, true, _ => setTime(Unix.time()));
 
-              () => Lwt_engine.stop_event(evt);
-            });
-
-            <label text={"Time: " ++ string_of_float(time)} />;
-          },
+                  () => Lwt_engine.stop_event(evt);
+                });
+                <label text={"Time: " ++ string_of_float(time)} />;
+              },
+            ),
           ~children,
         )
       )

--- a/examples/lambda-term/Lambda_term.re
+++ b/examples/lambda-term/Lambda_term.re
@@ -131,7 +131,7 @@ let reducer = (state, action) =>
   };
 
 let renderCounter = () =>
-  useReducer(reducer, 0, (count, dispatch) =>
+  useReducer(reducer, 0, ((count, dispatch)) =>
     <hbox>
       <button text="Decrement" onClick={() => dispatch(Decrement)} />
       <label text={"Counter: " ++ string_of_int(count)} />
@@ -154,7 +154,7 @@ module Clock = (
   val createComponent((render, ~children, ()) =>
         render(
           () =>
-            useState(0., (time, setTime) =>
+            useState(0., ((time, setTime)) =>
               useEffect(
                 () => {
                   let evt =

--- a/examples/lambda-term/Lambda_term.re
+++ b/examples/lambda-term/Lambda_term.re
@@ -130,15 +130,14 @@ let reducer = (state, action) =>
   | Decrement => state - 1
   };
 
-let renderCounter = () => {
-  let (count, dispatch) = useReducer(reducer, 0);
-
-  <hbox>
-    <button text="Decrement" onClick={() => dispatch(Decrement)} />
-    <label text={"Counter: " ++ string_of_int(count)} />
-    <button text="Increment" onClick={() => dispatch(Increment)} />
-  </hbox>;
-};
+let renderCounter = () =>
+  useReducer(reducer, 0, (count, dispatch) =>
+    <hbox>
+      <button text="Decrement" onClick={() => dispatch(Decrement)} />
+      <label text={"Counter: " ++ string_of_int(count)} />
+      <button text="Increment" onClick={() => dispatch(Increment)} />
+    </hbox>
+  );
 
 module CounterButtons = (
   val createComponent((render, ~children, ()) =>

--- a/examples/lambda-term/Lambda_term.re
+++ b/examples/lambda-term/Lambda_term.re
@@ -141,7 +141,9 @@ let renderCounter = () => {
 };
 
 module CounterButtons = (
-  val createComponent((render, ~children, ()) => render(renderCounter, ~children))
+  val createComponent((render, ~children, ()) =>
+        render(renderCounter, ~children)
+      )
 );
 /*
     Clock
@@ -153,17 +155,16 @@ module Clock = (
   val createComponent((render, ~children, ()) =>
         render(
           () =>
-            useState(
-              0.,
-              (time, setTime) => {
-                useEffect(() => {
+            useState(0., (time, setTime) =>
+              useEffect(
+                () => {
                   let evt =
                     Lwt_engine.on_timer(1.0, true, _ => setTime(Unix.time()));
 
                   () => Lwt_engine.stop_event(evt);
-                });
-                <label text={"Time: " ++ string_of_float(time)} />;
-              },
+                },
+                () => <label text={"Time: " ++ string_of_float(time)} />,
+              )
             ),
           ~children,
         )

--- a/lib/Reactify.re
+++ b/lib/Reactify.re
@@ -499,11 +499,11 @@ module Make = (ReconcilerImpl: Reconciler) => {
     switch (action) {
     | SetState(newState) => newState
     };
-  let useState = initialState => {
+  let useState = (initialState, f) => {
     let (componentState, dispatch) =
       useReducer(useStateReducer, initialState);
     let setState = newState => dispatch(SetState(newState));
-    (componentState, setState);
+    addState(f(componentState, setState));
   };
 
   let updateContainer = (container, component) => {

--- a/lib/Reactify.re
+++ b/lib/Reactify.re
@@ -11,7 +11,7 @@ module Make = (ReconcilerImpl: Reconciler) => {
     | Component(ComponentId.t, render)
     | Provider(render)
     | Empty(render)
-  and componentFunction('a) = unit => 'a
+  and componentFunction = unit => component
   and childComponents = list(component)
   /*
       An instance is a component that has been rendered.
@@ -110,8 +110,8 @@ module Make = (ReconcilerImpl: Reconciler) => {
 
   let empty: component = Empty(() => ([], [], __globalContext^));
 
-  type renderFunction('hook) =
-    (~children: list(component)=?, componentFunction('hook)) => component;
+  type renderFunction =
+    (~children: list(component)=?, componentFunction) => component;
   let render = (id: ComponentId.t, ~children: option(list(component))=?, c) => {
     ignore(children);
     let ret: component =
@@ -134,20 +134,18 @@ module Make = (ReconcilerImpl: Reconciler) => {
 
   module type Component = {
     type t;
-    type hook;
     /* let derp: unit => unit; */
     let createElement: t;
   };
 
-  type func('a, 'hook) = renderFunction('hook) => 'a;
+  type func('a) = renderFunction => 'a;
 
-  let component = (type a, type b, fn): (module Component with type t = a and type hook = b) => {
+  let component = (type a, fn): (module Component with type t = a) => {
     let id = ComponentId.newId(_uniqueIdScope);
     let boundFunc = fn(render(id));
     (module
      {
        type t = a;
-       type hook = b;
        let createElement = boundFunc;
      });
   };

--- a/lib/Reactify.re
+++ b/lib/Reactify.re
@@ -535,7 +535,7 @@ module Make = (ReconcilerImpl: Reconciler) => {
       };
     };
 
-    continuation(componentState, dispatch(currentContext));
+    continuation((componentState, dispatch(currentContext)));
   };
 
   /*
@@ -556,9 +556,9 @@ module Make = (ReconcilerImpl: Reconciler) => {
     _useReducer(
       useStateReducer,
       initialState,
-      (componentState, dispatch) => {
+      ((componentState, dispatch)) => {
         let setState = newState => dispatch(SetState(newState));
-        continuation(componentState, setState)
+        continuation((componentState, setState))
         |> addState(~state=initialState);
       },
     );

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -42,11 +42,8 @@ module type React = {
     | Component(ComponentId.t, render)
     | Provider(render)
     | Empty(render)
-  and wrappedElement =
-    | Hook(component, hook('t)): wrappedElement
-    | Regular(component): wrappedElement
-  and componentFunction = unit => wrappedElement
-  and childComponents = list(wrappedElement);
+  and componentFunction('hook) = unit => 'hook
+  and childComponents = list(component);
 
   type t;
 
@@ -67,18 +64,21 @@ module type React = {
        Component creation API
    */
   let primitiveComponent:
-    (~children: childComponents, primitives) => wrappedElement;
+    (~children: childComponents, primitives) => component;
 
   module type Component = {
     type t;
+    type hook;
     let createElement: t;
   };
 
-  type renderFunction =
-    (~children: childComponents=?, componentFunction) => component;
-  type func('a) = renderFunction => 'a;
+  type renderFunction('hook) =
+    (~children: childComponents=?, componentFunction('hook)) => component;
+  type func('a, 'hook) = renderFunction('hook) => 'a;
 
-  let component: func('a) => (module Component with type t = 'a);
+  let component:
+    func('a, 'hook) =>
+    (module Component with type t = 'a and type hook = 'hook);
 
   /*
        Component API
@@ -98,8 +98,7 @@ module type React = {
     (~condition: Effects.effectCondition=?, Effects.effectFunction) => unit;
 
   let useState:
-    ('state, ('state, 'state => unit) => ('a, hook('h))) =>
-    ('a, hook(('h, state('state))));
+    ('state, ('state, 'state => unit) => 'a) => hook(('a, state('state)));
 
   let useReducer:
     (('state, 'action) => 'state, 'state) => ('state, 'action => unit);

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -42,7 +42,7 @@ module type React = {
     | Component(ComponentId.t, render)
     | Provider(render)
     | Empty(render)
-  and componentFunction = unit => component
+  and primitiveComponent = (hook(unit), component)
   and childComponents = list(component);
 
   type t;
@@ -64,20 +64,17 @@ module type React = {
        Component creation API
    */
   let primitiveComponent:
-    (~children: childComponents, primitives) => component;
+    (~children: list(component), primitives) => component;
 
   module type Component = {
-    type t;
-    let createElement: t;
+    type hooks;
+    type createElement;
+    let createElement: createElement;
   };
 
-  type renderFunction =
-    (~children: childComponents=?, componentFunction) => component;
-  type func('a) = renderFunction => 'a;
-
-  let component:
-    func('a) =>
-    (module Component with type t = 'a);
+  let createComponent:
+    (('b, unit => component), component, 'a) =>
+    (module Component with type createElement = 'd and type hooks = 'e);
 
   /*
        Component API
@@ -97,7 +94,8 @@ module type React = {
     (~condition: Effects.effectCondition=?, Effects.effectFunction) => unit;
 
   let useState:
-    ('state, ('state, 'state => unit) => 'a) => hook(('a, state('state)));
+    ('state, ('state, 'state => unit) => (hook('a), 'b)) =>
+    (hook(('a, state('state))), 'b);
 
   let useReducer:
     (('state, 'action) => 'state, 'state) => ('state, 'action => unit);

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -3,6 +3,11 @@
  * with a mutable back-end. Similiar in spirit
  * to the reconciler interface provided via 'react-conciler'.
  */
+
+type hook('t);
+type state('a);
+let addState: 't => hook(state('t)) = x => Obj.magic(x);
+
 module type Reconciler = {
   /*
       Primitives is a variant type describing metadata needed
@@ -91,7 +96,7 @@ module type React = {
   let useEffect:
     (~condition: Effects.effectCondition=?, Effects.effectFunction) => unit;
 
-  let useState: 'state => ('state, 'state => unit);
+  let useState: ('state, ('state, 'state => unit) => 'a) => hook(state('a));
 
   let useReducer:
     (('state, 'action) => 'state, 'state) => ('state, 'action => unit);

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -40,7 +40,7 @@ module type React = {
     | Provider(render)
     | Empty(render)
   and componentFunction = unit => component
-  and childComponents = list(component)
+  and childComponents = list(component);
 
   type t;
 

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -42,7 +42,7 @@ module type React = {
     | Component(ComponentId.t, render)
     | Provider(render)
     | Empty(render)
-  and componentFunction('hook) = unit => 'hook
+  and componentFunction = unit => component
   and childComponents = list(component);
 
   type t;
@@ -68,17 +68,16 @@ module type React = {
 
   module type Component = {
     type t;
-    type hook;
     let createElement: t;
   };
 
-  type renderFunction('hook) =
-    (~children: childComponents=?, componentFunction('hook)) => component;
-  type func('a, 'hook) = renderFunction('hook) => 'a;
+  type renderFunction =
+    (~children: childComponents=?, componentFunction) => component;
+  type func('a) = renderFunction => 'a;
 
   let component:
-    func('a, 'hook) =>
-    (module Component with type t = 'a and type hook = 'hook);
+    func('a) =>
+    (module Component with type t = 'a);
 
   /*
        Component API

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -30,31 +30,17 @@ module type React = {
   type primitives;
   type node;
 
-  type element =
-    | Primitive(primitives)
-    | Component(ComponentId.t)
-    | Provider
-    | Empty
-  and renderedElement =
+  type renderedElement =
     | RenderedPrimitive(node)
-  and elementWithChildren = (
-    element,
-    childComponents,
-    Effects.effects,
-    Context.t,
-  )
-  /*
-     A component is our JSX primitive element - just an object
-     with a render method.
-     TODO: Can we clean this interface up and just make component
-     a function of type unit => elementWithChildren ?
-   */
-  and component = {
-    element,
-    render: unit => elementWithChildren,
-  }
+  and elementWithChildren = (childComponents, Effects.effects, Context.t)
+  and render = unit => elementWithChildren
+  and component =
+    | Primitive(primitives, render)
+    | Component(ComponentId.t, render)
+    | Provider(render)
+    | Empty(render)
   and componentFunction = unit => component
-  and childComponents = list(component);
+  and childComponents = list(component)
 
   type t;
 

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -105,14 +105,14 @@ module type React = {
     (hook(('a, effect)), 'b);
 
   let useState:
-    ('state, ('state, 'state => unit) => (hook('a), 'b)) =>
+    ('state, (('state, 'state => unit)) => (hook('a), 'b)) =>
     (hook(('a, state('state))), 'b);
 
   let useReducer:
     (
       ('state, 'action) => 'state,
       'state,
-      ('state, 'action => unit) => (hook('a), 'b)
+      (('state, 'action => unit)) => (hook('a), 'b)
     ) =>
     (hook(('a, reducer('state, 'action))), 'b);
 };

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -32,6 +32,7 @@ module type React = {
   type node;
   type hook('t);
   type state('a);
+  type effect;
 
   type renderedElement =
     | RenderedPrimitive(node)
@@ -95,7 +96,12 @@ module type React = {
   let empty: elementHook;
 
   let useEffect:
-    (~condition: Effects.effectCondition=?, Effects.effectFunction) => unit;
+    (
+      ~condition: Effects.effectCondition=?,
+      Effects.effectFunction,
+      unit => (hook('a), 'b)
+    ) =>
+    (hook(('a, effect)), 'b);
 
   let useState:
     ('state, ('state, 'state => unit) => (hook('a), 'b)) =>

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -35,15 +35,14 @@ module type React = {
 
   type renderedElement =
     | RenderedPrimitive(node)
-  and elementWithChildren = (childComponents, Effects.effects, Context.t)
+  and elementWithChildren = (list(component), Effects.effects, Context.t)
   and render = unit => elementWithChildren
   and component =
     | Primitive(primitives, render)
     | Component(ComponentId.t, render)
     | Provider(render)
     | Empty(render)
-  and primitiveComponent = (hook(unit), component)
-  and childComponents = list(component);
+  and primitiveComponent = (hook(unit), component);
 
   type t;
 
@@ -58,13 +57,13 @@ module type React = {
       node
     ) =>
     t;
-  let updateContainer: (t, component) => unit;
+  let updateContainer: (t, primitiveComponent) => unit;
 
   /*
        Component creation API
    */
   let primitiveComponent:
-    (~children: list(component), primitives) => component;
+    (~children: list(primitiveComponent), primitives) => primitiveComponent;
 
   module type Component = {
     type hooks;
@@ -73,22 +72,22 @@ module type React = {
   };
 
   let createComponent:
-    (('b, unit => component), component, 'a) =>
-    (module Component with type createElement = 'd and type hooks = 'e);
+    (((unit => ('a, component), ~children: list(primitiveComponent)) => primitiveComponent) => 'b) =>
+    (module Component with type createElement = 'b and type hooks = 'a);
 
   /*
        Component API
    */
 
   type providerConstructor('t) =
-    (~children: childComponents, ~value: 't, unit) => component;
+    (~children: list(primitiveComponent), ~value: 't, unit) => primitiveComponent;
   type context('t);
 
   let getProvider: context('t) => providerConstructor('t);
   let createContext: 't => context('t);
   let useContext: context('t) => 't;
 
-  let empty: component;
+  let empty: primitiveComponent;
 
   let useEffect:
     (~condition: Effects.effectCondition=?, Effects.effectFunction) => unit;

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -34,6 +34,7 @@ module type React = {
   type state('s);
   type reducer('s, 'a);
   type effect;
+  type context('t);
 
   type renderedElement =
     | RenderedPrimitive(node)
@@ -88,11 +89,12 @@ module type React = {
 
   type providerConstructor('t) =
     (~children: list(elementHook), ~value: 't, unit) => elementHook;
-  type context('t);
+  type contextValue('t);
 
-  let getProvider: context('t) => providerConstructor('t);
-  let createContext: 't => context('t);
-  let useContext: context('t) => 't;
+  let getProvider: contextValue('t) => providerConstructor('t);
+  let createContext: 't => contextValue('t);
+  let useContext:
+    (contextValue('t), 't => (hook('a), 'b)) => (hook(('a, context('t))), 'b);
 
   let empty: elementHook;
 

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -35,14 +35,14 @@ module type React = {
 
   type renderedElement =
     | RenderedPrimitive(node)
-  and elementWithChildren = (list(component), Effects.effects, Context.t)
+  and elementWithChildren = (list(element), Effects.effects, Context.t)
   and render = unit => elementWithChildren
-  and component =
+  and element =
     | Primitive(primitives, render)
     | Component(ComponentId.t, render)
     | Provider(render)
     | Empty(render)
-  and primitiveComponent = (hook(unit), component);
+  and elementHook = (hook(unit), element);
 
   type t;
 
@@ -57,13 +57,13 @@ module type React = {
       node
     ) =>
     t;
-  let updateContainer: (t, primitiveComponent) => unit;
+  let updateContainer: (t, elementHook) => unit;
 
   /*
        Component creation API
    */
   let primitiveComponent:
-    (~children: list(primitiveComponent), primitives) => primitiveComponent;
+    (~children: list(elementHook), primitives) => elementHook;
 
   module type Component = {
     type hooks;
@@ -72,22 +72,27 @@ module type React = {
   };
 
   let createComponent:
-    (((unit => ('a, component), ~children: list(primitiveComponent)) => primitiveComponent) => 'b) =>
-    (module Component with type createElement = 'b and type hooks = 'a);
+    (
+      (
+        (unit => ('h, element), ~children: list(elementHook)) => elementHook
+      ) =>
+      'c
+    ) =>
+    (module Component with type createElement = 'c and type hooks = 'h);
 
   /*
        Component API
    */
 
   type providerConstructor('t) =
-    (~children: list(primitiveComponent), ~value: 't, unit) => primitiveComponent;
+    (~children: list(elementHook), ~value: 't, unit) => elementHook;
   type context('t);
 
   let getProvider: context('t) => providerConstructor('t);
   let createContext: 't => context('t);
   let useContext: context('t) => 't;
 
-  let empty: primitiveComponent;
+  let empty: elementHook;
 
   let useEffect:
     (~condition: Effects.effectCondition=?, Effects.effectFunction) => unit;

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -31,7 +31,8 @@ module type React = {
   type primitives;
   type node;
   type hook('t);
-  type state('a);
+  type state('s);
+  type reducer('s, 'a);
   type effect;
 
   type renderedElement =
@@ -108,5 +109,10 @@ module type React = {
     (hook(('a, state('state))), 'b);
 
   let useReducer:
-    (('state, 'action) => 'state, 'state) => ('state, 'action => unit);
+    (
+      ('state, 'action) => 'state,
+      'state,
+      ('state, 'action => unit) => (hook('a), 'b)
+    ) =>
+    (hook(('a, reducer('state, 'action))), 'b);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reason-reactify",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Reason workflow with Esy",
   "license": "MIT",
   "scripts": {

--- a/test/ContainerTest.re
+++ b/test/ContainerTest.re
@@ -44,12 +44,13 @@ test("Container", () => {
                 2,
                 (s, setS) => {
                   print_endline("Value: " ++ string_of_int(s));
-                  useEffect(() => {
-                    let unsubscribe = Event.subscribe(event, v => setS(v));
-                    () => unsubscribe();
-                  });
-
-                  <aComponent testVal=s />;
+                  useEffect(
+                    () => {
+                      let unsubscribe = Event.subscribe(event, v => setS(v));
+                      () => unsubscribe();
+                    },
+                    () => <aComponent testVal=s />,
+                  );
                 },
               ),
             ~children,

--- a/test/ContainerTest.re
+++ b/test/ContainerTest.re
@@ -42,7 +42,7 @@ test("Container", () => {
             () =>
               useState(
                 2,
-                (s, setS) => {
+                ((s, setS)) => {
                   print_endline("Value: " ++ string_of_int(s));
                   useEffect(
                     () => {

--- a/test/ContainerTest.re
+++ b/test/ContainerTest.re
@@ -37,7 +37,7 @@ test("Container", () => {
   });
 
   module ComponentThatUpdatesState = (
-    val component((render, ~children, ~event: Event.t(int), ()) =>
+    val createComponent((render, ~children, ~event: Event.t(int), ()) =>
           render(
             () => {
               let (s, setS) = useState(2);

--- a/test/ContainerTest.re
+++ b/test/ContainerTest.re
@@ -39,17 +39,19 @@ test("Container", () => {
   module ComponentThatUpdatesState = (
     val createComponent((render, ~children, ~event: Event.t(int), ()) =>
           render(
-            () => {
-              let (s, setS) = useState(2);
+            () =>
+              useState(
+                2,
+                (s, setS) => {
+                  print_endline("Value: " ++ string_of_int(s));
+                  useEffect(() => {
+                    let unsubscribe = Event.subscribe(event, v => setS(v));
+                    () => unsubscribe();
+                  });
 
-              print_endline("Value: " ++ string_of_int(s));
-              useEffect(() => {
-                let unsubscribe = Event.subscribe(event, v => setS(v));
-                () => unsubscribe();
-              });
-
-              <aComponent testVal=s />;
-            },
+                  <aComponent testVal=s />;
+                },
+              ),
             ~children,
           )
         )

--- a/test/HooksUseContextTest.re
+++ b/test/HooksUseContextTest.re
@@ -27,11 +27,7 @@ test("HooksUseContext", () => {
     module ComponentThatUsesContext = (
       val createComponent((render, ~children, ()) =>
             render(
-              () => {
-                let ctx = useContext(testContext);
-
-                <aComponent testVal=ctx />;
-              },
+              () => useContext(testContext, ctx => <aComponent testVal=ctx />),
               ~children,
             )
           )
@@ -54,11 +50,10 @@ test("HooksUseContext", () => {
     module ComponentThatUsesContext = (
       val createComponent((render, ~children, ()) =>
             render(
-              () => {
-                let ctx = useContext(testContext);
-
-                <provider value=9> <aComponent testVal=ctx /> </provider>;
-              },
+              () =>
+                useContext(testContext, ctx =>
+                  <provider value=9> <aComponent testVal=ctx /> </provider>
+                ),
               ~children,
             )
           )
@@ -81,10 +76,7 @@ test("HooksUseContext", () => {
     module ComponentThatUsesContext = (
       val createComponent((render, ~children, ()) =>
             render(
-              () => {
-                let ctx = useContext(testContext);
-                <aComponent testVal=ctx />;
-              },
+              () => useContext(testContext, ctx => <aComponent testVal=ctx />),
               ~children,
             )
           )

--- a/test/HooksUseContextTest.re
+++ b/test/HooksUseContextTest.re
@@ -25,7 +25,7 @@ test("HooksUseContext", () => {
     let testContext = createContext(2);
 
     module ComponentThatUsesContext = (
-      val component((render, ~children, ()) =>
+      val createComponent((render, ~children, ()) =>
             render(
               () => {
                 let ctx = useContext(testContext);
@@ -52,7 +52,7 @@ test("HooksUseContext", () => {
     let provider = getProvider(testContext);
 
     module ComponentThatUsesContext = (
-      val component((render, ~children, ()) =>
+      val createComponent((render, ~children, ()) =>
             render(
               () => {
                 let ctx = useContext(testContext);
@@ -79,7 +79,7 @@ test("HooksUseContext", () => {
     let provider = getProvider(testContext);
 
     module ComponentThatUsesContext = (
-      val component((render, ~children, ()) =>
+      val createComponent((render, ~children, ()) =>
             render(
               () => {
                 let ctx = useContext(testContext);

--- a/test/HooksUseEffectTest.re
+++ b/test/HooksUseEffectTest.re
@@ -27,16 +27,14 @@ module ComponentWithEffectOnMount = (
           (),
         ) =>
         render(
-          () => {
-            /* Hooks */
-            useEffect(() => {
-              functionToCallOnMount();
-              () => functionToCallOnUnmount();
-            });
-            /* End Hooks */
-
-            <bComponent />;
-          },
+          () =>
+            useEffect(
+              () => {
+                functionToCallOnMount();
+                () => functionToCallOnUnmount();
+              },
+              () => <bComponent />,
+            ),
           ~children,
         )
       )
@@ -52,7 +50,7 @@ module ComponentWithEmptyConditionalEffect = (
           (),
         ) =>
         render(
-          () => {
+          () =>
             /* Hooks */
             useEffect(
               ~condition=MountUnmount,
@@ -60,11 +58,8 @@ module ComponentWithEmptyConditionalEffect = (
                 functionToCallOnMount();
                 () => functionToCallOnUnmount();
               },
-            );
-            /* End Hooks */
-
-            <bComponent />;
-          },
+              () => <bComponent />,
+            ),
           ~children,
         )
       )

--- a/test/HooksUseEffectTest.re
+++ b/test/HooksUseEffectTest.re
@@ -18,7 +18,7 @@ let cComponent = (~children, ()) => primitiveComponent(C, ~children);
 let noop = () => ();
 
 module ComponentWithEffectOnMount = (
-  val component(
+  val createComponent(
         (
           render,
           ~children,
@@ -43,7 +43,7 @@ module ComponentWithEffectOnMount = (
 );
 
 module ComponentWithEmptyConditionalEffect = (
-  val component(
+  val createComponent(
         (
           render,
           ~children,

--- a/test/HooksUseReducerTest.re
+++ b/test/HooksUseReducerTest.re
@@ -27,7 +27,7 @@ let reducer = (state, action) =>
   };
 
 module ComponentWithState = (
-  val component((render, ~children, ()) =>
+  val createComponent((render, ~children, ()) =>
         render(
           () => {
             /* Hooks */
@@ -60,7 +60,7 @@ test("useReducer", () => {
   });
 
   module ComponentThatDispatchesIncreaseAction = (
-    val component(
+    val createComponent(
           (render, ~children, ~event: Event.t(unit), ~initialValue: int, ()) =>
           render(
             () => {
@@ -183,7 +183,7 @@ test("useReducer", () => {
   });
 
   module ComponentThatDispatchesIncreaseActionAndRendersChildren = (
-    val component(
+    val createComponent(
           (render, ~children, ~event: Event.t(unit), ~initialValue: int, ()) =>
           render(
             () => {

--- a/test/HooksUseReducerTest.re
+++ b/test/HooksUseReducerTest.re
@@ -68,13 +68,14 @@ test("useReducer", () => {
               let (s, dispatch) = useReducer(reducer, initialValue);
               /* End hooks */
 
-              useEffect(() => {
-                let unsubscribe =
-                  Event.subscribe(event, () => dispatch(Increase));
-                () => unsubscribe();
-              });
-
-              <aComponent testVal=s />;
+              useEffect(
+                () => {
+                  let unsubscribe =
+                    Event.subscribe(event, () => dispatch(Increase));
+                  () => unsubscribe();
+                },
+                () => <aComponent testVal=s />,
+              );
             },
             ~children,
           )
@@ -187,17 +188,16 @@ test("useReducer", () => {
           (render, ~children, ~event: Event.t(unit), ~initialValue: int, ()) =>
           render(
             () => {
-              /* Hooks */
               let (s, dispatch) = useReducer(reducer, initialValue);
 
-              useEffect(() => {
-                let unsubscribe =
-                  Event.subscribe(event, () => dispatch(Increase));
-                () => unsubscribe();
-              });
-              /* End Hooks */
-
-              <aComponent testVal=s> ...children </aComponent>;
+              useEffect(
+                () => {
+                  let unsubscribe =
+                    Event.subscribe(event, () => dispatch(Increase));
+                  () => unsubscribe();
+                },
+                () => <aComponent testVal=s> ...children </aComponent>,
+              );
             },
             ~children,
           )
@@ -241,5 +241,4 @@ test("useReducer", () => {
       TreeNode(Root, [TreeNode(A(4), [TreeLeaf(A(13))])]);
     validateStructure(rootNode, expectedStructure);
   });
-
 });

--- a/test/HooksUseReducerTest.re
+++ b/test/HooksUseReducerTest.re
@@ -30,7 +30,7 @@ module ComponentWithState = (
   val createComponent((render, ~children, ()) =>
         render(
           () =>
-            useReducer(reducer, 2, (s, _dispatch) =>
+            useReducer(reducer, 2, ((s, _dispatch)) =>
               <aComponent testVal=s />
             ),
           ~children,
@@ -61,7 +61,7 @@ test("useReducer", () => {
           (render, ~children, ~event: Event.t(unit), ~initialValue: int, ()) =>
           render(
             () =>
-              useReducer(reducer, initialValue, (s, dispatch) =>
+              useReducer(reducer, initialValue, ((s, dispatch)) =>
                 useEffect(
                   () => {
                     let unsubscribe =
@@ -182,7 +182,7 @@ test("useReducer", () => {
           (render, ~children, ~event: Event.t(unit), ~initialValue: int, ()) =>
           render(
             () =>
-              useReducer(reducer, initialValue, (s, dispatch) =>
+              useReducer(reducer, initialValue, ((s, dispatch)) =>
                 useEffect(
                   () => {
                     let unsubscribe =

--- a/test/HooksUseReducerTest.re
+++ b/test/HooksUseReducerTest.re
@@ -29,13 +29,10 @@ let reducer = (state, action) =>
 module ComponentWithState = (
   val createComponent((render, ~children, ()) =>
         render(
-          () => {
-            /* Hooks */
-            let (s, _dispatch) = useReducer(reducer, 2);
-            /* End hooks */
-
-            <aComponent testVal=s />;
-          },
+          () =>
+            useReducer(reducer, 2, (s, _dispatch) =>
+              <aComponent testVal=s />
+            ),
           ~children,
         )
       )
@@ -63,20 +60,17 @@ test("useReducer", () => {
     val createComponent(
           (render, ~children, ~event: Event.t(unit), ~initialValue: int, ()) =>
           render(
-            () => {
-              /* Hooks */
-              let (s, dispatch) = useReducer(reducer, initialValue);
-              /* End hooks */
-
-              useEffect(
-                () => {
-                  let unsubscribe =
-                    Event.subscribe(event, () => dispatch(Increase));
-                  () => unsubscribe();
-                },
-                () => <aComponent testVal=s />,
-              );
-            },
+            () =>
+              useReducer(reducer, initialValue, (s, dispatch) =>
+                useEffect(
+                  () => {
+                    let unsubscribe =
+                      Event.subscribe(event, () => dispatch(Increase));
+                    () => unsubscribe();
+                  },
+                  () => <aComponent testVal=s />,
+                )
+              ),
             ~children,
           )
         )
@@ -187,18 +181,17 @@ test("useReducer", () => {
     val createComponent(
           (render, ~children, ~event: Event.t(unit), ~initialValue: int, ()) =>
           render(
-            () => {
-              let (s, dispatch) = useReducer(reducer, initialValue);
-
-              useEffect(
-                () => {
-                  let unsubscribe =
-                    Event.subscribe(event, () => dispatch(Increase));
-                  () => unsubscribe();
-                },
-                () => <aComponent testVal=s> ...children </aComponent>,
-              );
-            },
+            () =>
+              useReducer(reducer, initialValue, (s, dispatch) =>
+                useEffect(
+                  () => {
+                    let unsubscribe =
+                      Event.subscribe(event, () => dispatch(Increase));
+                    () => unsubscribe();
+                  },
+                  () => <aComponent testVal=s> ...children </aComponent>,
+                )
+              ),
             ~children,
           )
         )

--- a/test/HooksUseStateTest.re
+++ b/test/HooksUseStateTest.re
@@ -48,16 +48,14 @@ test("useState", () => {
     val createComponent((render, ~children, ~event: Event.t(int), ()) =>
           render(
             () =>
-              useState(
-                2,
-                (s, setS) => {
-                  useEffect(() => {
+              useState(2, (s, setS) =>
+                useEffect(
+                  () => {
                     let unsubscribe = Event.subscribe(event, v => setS(v));
                     () => unsubscribe();
-                  });
-
-                  <aComponent testVal=s />;
-                },
+                  },
+                  () => <aComponent testVal=s />,
+                )
               ),
             ~children,
           )
@@ -154,15 +152,14 @@ test("useState", () => {
     val createComponent((render, ~children, ~event: Event.t(int), ()) =>
           render(
             () =>
-              useState(
-                2,
-                (s, setS) => {
-                  useEffect(() => {
+              useState(2, (s, setS) =>
+                useEffect(
+                  () => {
                     let unsubscribe = Event.subscribe(event, v => setS(v));
                     () => unsubscribe();
-                  });
-                  <aComponent testVal=s> ...children </aComponent>;
-                },
+                  },
+                  () => <aComponent testVal=s> ...children </aComponent>,
+                )
               ),
             ~children,
           )
@@ -209,19 +206,19 @@ test("useState", () => {
           render(
             () =>
               /* Hooks */
-              useState(
-                RenderAComponentWithState,
-                (s, setS) => {
-                  useEffect(() => {
+              useState(RenderAComponentWithState, (s, setS) =>
+                useEffect(
+                  () => {
                     let unsubscribe = Event.subscribe(event, v => setS(v));
                     () => unsubscribe();
-                  });
-                  switch (s) {
-                  /* | Nothing => () */
-                  | RenderAComponentWithState => <ComponentWithState />
-                  | RenderAComponent(x) => <aComponent testVal=x />
-                  };
-                },
+                  },
+                  () =>
+                    switch (s) {
+                    /* | Nothing => () */
+                    | RenderAComponentWithState => <ComponentWithState />
+                    | RenderAComponent(x) => <aComponent testVal=x />
+                    },
+                )
               ),
             ~children,
           )

--- a/test/HooksUseStateTest.re
+++ b/test/HooksUseStateTest.re
@@ -20,7 +20,7 @@ let cComponent = (~children, ()) => primitiveComponent(C, ~children);
 module ComponentWithState = (
   val createComponent((render, ~children, ()) =>
         render(
-          () => useState(2, (s, _setS) => <aComponent testVal=s />),
+          () => useState(2, ((s, _setS)) => <aComponent testVal=s />),
           ~children,
         )
       )
@@ -48,7 +48,7 @@ test("useState", () => {
     val createComponent((render, ~children, ~event: Event.t(int), ()) =>
           render(
             () =>
-              useState(2, (s, setS) =>
+              useState(2, ((s, setS)) =>
                 useEffect(
                   () => {
                     let unsubscribe = Event.subscribe(event, v => setS(v));
@@ -152,7 +152,7 @@ test("useState", () => {
     val createComponent((render, ~children, ~event: Event.t(int), ()) =>
           render(
             () =>
-              useState(2, (s, setS) =>
+              useState(2, ((s, setS)) =>
                 useEffect(
                   () => {
                     let unsubscribe = Event.subscribe(event, v => setS(v));
@@ -206,7 +206,7 @@ test("useState", () => {
           render(
             () =>
               /* Hooks */
-              useState(RenderAComponentWithState, (s, setS) =>
+              useState(RenderAComponentWithState, ((s, setS)) =>
                 useEffect(
                   () => {
                     let unsubscribe = Event.subscribe(event, v => setS(v));

--- a/test/HooksUseStateTest.re
+++ b/test/HooksUseStateTest.re
@@ -18,7 +18,7 @@ let bComponent = (~children, ()) => primitiveComponent(B, ~children);
 let cComponent = (~children, ()) => primitiveComponent(C, ~children);
 
 module ComponentWithState = (
-  val component((render, ~children, ()) =>
+  val createComponent((render, ~children, ()) =>
         render(
           () => {
             /* Hooks */
@@ -51,7 +51,7 @@ test("useState", () => {
   });
 
   module ComponentThatUpdatesState = (
-    val component((render, ~children, ~event: Event.t(int), ()) =>
+    val createComponent((render, ~children, ~event: Event.t(int), ()) =>
           render(
             () => {
               /* Hooks */
@@ -157,7 +157,7 @@ test("useState", () => {
   });
 
   module ComponentThatUpdatesStateAndRendersChildren = (
-    val component((render, ~children, ~event: Event.t(int), ()) =>
+    val createComponent((render, ~children, ~event: Event.t(int), ()) =>
           render(
             () => {
               /* Hooks */
@@ -211,7 +211,7 @@ test("useState", () => {
   });
 
   module ComponentThatWrapsEitherPrimitiveOrComponent = (
-    val component((render, ~children, ~event: Event.t(renderOption), ()) =>
+    val createComponent((render, ~children, ~event: Event.t(renderOption), ()) =>
           render(
             () => {
               /* Hooks */

--- a/test/PrimitiveComponentTest.re
+++ b/test/PrimitiveComponentTest.re
@@ -16,7 +16,7 @@ let bComponent = (~children, ()) => primitiveComponent(B, ~children);
 let cComponent = (~children, ()) => primitiveComponent(C, ~children);
 
 module CustomComponent = (
-  val component((render, ~children, ()) =>
+  val createComponent((render, ~children, ()) =>
         render(
           () =>
             <aComponent testVal=1> <bComponent /> <bComponent /> </aComponent>,

--- a/test/StatelessComponentTest.re
+++ b/test/StatelessComponentTest.re
@@ -16,7 +16,7 @@ let bComponent = (~children, ()) => primitiveComponent(B, ~children);
 let cComponent = (~children, ()) => primitiveComponent(C, ~children);
 
 module ComponentWrappingB = (
-  val component((render, ~children, ()) =>
+  val createComponent((render, ~children, ()) =>
         render(() => <bComponent />, ~children)
       )
 );
@@ -35,7 +35,7 @@ test("StatelessComponentTest", () => {
   });
 
   module ComponentWrappingAWithProps = (
-    val component((render, ~children, ~v, ()) =>
+    val createComponent((render, ~children, ~v, ()) =>
           render(() => <aComponent testVal=v />, ~children)
         )
   );
@@ -107,7 +107,7 @@ test("StatelessComponentTest", () => {
   });
 
   module ComponentWithWrappedComponents = (
-    val component((render, ~children, ()) =>
+    val createComponent((render, ~children, ()) =>
           render(
             () => <aComponent testVal=1> <ComponentWrappingB /> </aComponent>,
             ~children,
@@ -128,7 +128,7 @@ test("StatelessComponentTest", () => {
   });
 
   module ComponentThatRendersChildren = (
-    val component((render, ~children, ()) =>
+    val createComponent((render, ~children, ()) =>
           render(
             () => <aComponent testVal=1> ...children </aComponent>,
             ~children,
@@ -171,7 +171,7 @@ test("StatelessComponentTest", () => {
   });
 
   module ComponentWithVisibilityToggle = (
-    val component((render, ~visible=true, ~children, ()) =>
+    val createComponent((render, ~visible=true, ~children, ()) =>
           render(() =>
             visible ?
               <aComponent testVal=1> ...children </aComponent> :

--- a/test/StatelessComponentTest.re
+++ b/test/StatelessComponentTest.re
@@ -172,10 +172,12 @@ test("StatelessComponentTest", () => {
 
   module ComponentWithVisibilityToggle = (
     val createComponent((render, ~visible=true, ~children, ()) =>
-          render(() =>
-            visible ?
-              <aComponent testVal=1> ...children </aComponent> :
-              TestReact.empty
+          render(
+            () =>
+              visible ?
+                <aComponent testVal=1> ...children </aComponent> :
+                TestReact.empty,
+            ~children,
           )
         )
   );


### PR DESCRIPTION
⚠️  Warning: Breaks public API ⚠️ 

Breaking API changes:
- Hooks are now implemented in a continuation-passing style
- `component` has been renamed to `createComponent` to avoid confusion (happy to roll this back or provide a more progressive migration path)

Related to https://github.com/revery-ui/reason-reactify/issues/39. It doesn't fix that issue though, as it's still definitely allowed to call `useState` from anywhere in the code.

### Why

The main idea behind this PR is to encode part of the ["Rules of Hooks"](https://reactjs.org/docs/hooks-rules.html) in the type system + API. In this case, the rule targeted is "Only Call Hooks at the Top Level". After this PR, using a hook in one branch of a conditional expression will fail to compile. One can still decide to call hooks inside conditionals statements, as long as the types of these branches coincide.

In a future PR, we could tackle the second rule: "Only Call Hooks from React Functions", by exposing the hooks functions (`useState`, `useReducer` etc) from inside the `createComponent` callback.

### What

This PR introduces a new polymorphic type `hook('t)` that allows to represent the different hooks that are used inside a component render function.
Besides the new type `hook('t)`, there is one new type for each basic hook: `effect`, `state('s)`, and `reducer('s, 'a)`.

### TODO

- [x] Find a type representation for hooks + companion API
- [x] Adapt `useState` + examples
- [x] Adapt `useReducer` + examples
- [x] Adapt `useEffect` + examples
- [x] Adapt `useContext` + examples (should we change this one for consistency? or leave it like it is)
- [ ] Create a ppx `let%hook` to make continuation-passing style consumption easier (maybe in a new PR?)