### PR TITLE
Test Coverage: Add test case for multiple subsequent setState calls

### DIFF
--- a/test/HooksUseStateTest.re
+++ b/test/HooksUseStateTest.re
@@ -70,6 +70,36 @@ test("useState", () => {
         )
   );
 
+  module ComponentThatUpdatesMultipleStates = (
+    val component((render, ~children, ~event: Event.t((int, int, int)), ()) =>
+          render(
+            () => {
+              /* Hooks */
+              let (s1, setS1) = useState(1);
+              let (s2, setS2) = useState(2);
+              let (s3, setS3) = useState(3);
+              /* End hooks */
+
+              useEffect(() => {
+                let unsubscribe = Event.subscribe(event, ((v1, v2, v3)) => {
+                  setS1(v1);  
+                  setS2(v2);
+                  setS3(v3);
+                });
+                () => unsubscribe();
+              });
+
+              <bComponent>
+                  <aComponent testVal=s1 />
+                  <aComponent testVal=s2 />
+                  <aComponent testVal=s3 />
+              </bComponent>
+            },
+            ~children,
+          )
+        )
+  );
+
   test("useState updates state with set function", () => {
     let rootNode = createRootNode();
 
@@ -112,7 +142,6 @@ test("useState", () => {
 
   test("useState set state persists across renders", () => {
     let rootNode = createRootNode();
-
     let container = createContainer(rootNode);
 
     let event: Event.t(int) = Event.create();
@@ -120,15 +149,42 @@ test("useState", () => {
     updateContainer(container, <ComponentThatUpdatesState event />);
 
     Event.dispatch(event, 5);
-
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(5))]);
     validateStructure(rootNode, expectedStructure);
 
-    updateContainer(container, <ComponentThatUpdatesState event />);
+    Event.dispatch(event, 6);
+    let expectedStructure: tree(primitives) =
+      TreeNode(Root, [TreeLeaf(A(6))]);
+    validateStructure(rootNode, expectedStructure);
+
+    Event.dispatch(event, 7);
+    let expectedStructure: tree(primitives) =
+      TreeNode(Root, [TreeLeaf(A(7))]);
+    validateStructure(rootNode, expectedStructure);
+  });
+
+  test("multiple setState calls", () => {
+    let rootNode = createRootNode();
+
+    let container = createContainer(rootNode);
+
+    let event: Event.t((int, int, int)) = Event.create();
+
+    updateContainer(container, <ComponentThatUpdatesMultipleStates event />);
+    let expectedStructure: tree(primitives) =
+      TreeNode(Root, [TreeNode(B, [TreeLeaf(A(1)), TreeLeaf(A(2)), TreeLeaf(A(3))])]);
+    validateStructure(rootNode, expectedStructure);
+
+    Event.dispatch(event, (10, 11, 12));
 
     let expectedStructure: tree(primitives) =
-      TreeNode(Root, [TreeLeaf(A(5))]);
+      TreeNode(Root, [TreeNode(B, [TreeLeaf(A(10)), TreeLeaf(A(11)), TreeLeaf(A(12))])]);
+    validateStructure(rootNode, expectedStructure);
+
+    updateContainer(container, <ComponentThatUpdatesMultipleStates event />);
+    let expectedStructure: tree(primitives) =
+      TreeNode(Root, [TreeNode(B, [TreeLeaf(A(10)), TreeLeaf(A(11)), TreeLeaf(A(12))])]);
     validateStructure(rootNode, expectedStructure);
   });
 

--- a/test/HooksUseStateTest.re
+++ b/test/HooksUseStateTest.re
@@ -66,26 +66,28 @@ test("useState", () => {
     val component((render, ~children, ~event: Event.t((int, int, int)), ()) =>
           render(
             () => {
-              /* Hooks */
-              let (s1, setS1) = useState(1);
-              let (s2, setS2) = useState(2);
-              let (s3, setS3) = useState(3);
-              /* End hooks */
+              useStateExperimental(1, ((s1, setS1)) => {
+              useStateExperimental(2, ((s2, setS2)) => {
+              useStateExperimental(3, ((s3, setS3)) => {
 
-              useEffect(() => {
+              useEffectExperimental(() => {
                 let unsubscribe = Event.subscribe(event, ((v1, v2, v3)) => {
                   setS1(v1);  
                   setS2(v2);
                   setS3(v3);
                 });
                 () => unsubscribe();
+              }, () => {
+                  <bComponent>
+                      <aComponent testVal=s1 />
+                      <aComponent testVal=s2 />
+                      <aComponent testVal=s3 />
+                  </bComponent>
               });
 
-              <bComponent>
-                  <aComponent testVal=s1 />
-                  <aComponent testVal=s2 />
-                  <aComponent testVal=s3 />
-              </bComponent>
+              })  ;
+              });   
+            });
             },
             ~children,
           )

--- a/test/HooksUseStateTest.re
+++ b/test/HooksUseStateTest.re
@@ -100,51 +100,6 @@ test("useState", () => {
         )
   );
 
-  test("multiple setState calls", () => {
-    let rootNode = createRootNode();
-
-    let container = createContainer(rootNode);
-
-    let event: Event.t((int, int, int)) = Event.create();
-
-    updateContainer(container, <ComponentThatUpdatesMultipleStates event />);
-    let expectedStructure: tree(primitives) =
-      TreeNode(
-        Root,
-        [
-          TreeNode(B, [TreeLeaf(A(1)), TreeLeaf(A(2)), TreeLeaf(A(3))]),
-        ],
-      );
-    validateStructure(rootNode, expectedStructure);
-
-    Event.dispatch(event, (10, 11, 12));
-
-    let expectedStructure: tree(primitives) =
-      TreeNode(
-        Root,
-        [
-          TreeNode(
-            B,
-            [TreeLeaf(A(10)), TreeLeaf(A(11)), TreeLeaf(A(12))],
-          ),
-        ],
-      );
-    validateStructure(rootNode, expectedStructure);
-
-    updateContainer(container, <ComponentThatUpdatesMultipleStates event />);
-    let expectedStructure: tree(primitives) =
-      TreeNode(
-        Root,
-        [
-          TreeNode(
-            B,
-            [TreeLeaf(A(10)), TreeLeaf(A(11)), TreeLeaf(A(12))],
-          ),
-        ],
-      );
-    validateStructure(rootNode, expectedStructure);
-  });
-
   test("useState updates state with set function", () => {
     let rootNode = createRootNode();
 
@@ -204,6 +159,51 @@ test("useState", () => {
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(5))]);
+    validateStructure(rootNode, expectedStructure);
+  });
+
+  test("multiple setState calls", () => {
+    let rootNode = createRootNode();
+
+    let container = createContainer(rootNode);
+
+    let event: Event.t((int, int, int)) = Event.create();
+
+    updateContainer(container, <ComponentThatUpdatesMultipleStates event />);
+    let expectedStructure: tree(primitives) =
+      TreeNode(
+        Root,
+        [
+          TreeNode(B, [TreeLeaf(A(1)), TreeLeaf(A(2)), TreeLeaf(A(3))]),
+        ],
+      );
+    validateStructure(rootNode, expectedStructure);
+
+    Event.dispatch(event, (10, 11, 12));
+
+    let expectedStructure: tree(primitives) =
+      TreeNode(
+        Root,
+        [
+          TreeNode(
+            B,
+            [TreeLeaf(A(10)), TreeLeaf(A(11)), TreeLeaf(A(12))],
+          ),
+        ],
+      );
+    validateStructure(rootNode, expectedStructure);
+
+    updateContainer(container, <ComponentThatUpdatesMultipleStates event />);
+    let expectedStructure: tree(primitives) =
+      TreeNode(
+        Root,
+        [
+          TreeNode(
+            B,
+            [TreeLeaf(A(10)), TreeLeaf(A(11)), TreeLeaf(A(12))],
+          ),
+        ],
+      );
     validateStructure(rootNode, expectedStructure);
   });
 

--- a/test/HooksUseStateTest.re
+++ b/test/HooksUseStateTest.re
@@ -100,6 +100,51 @@ test("useState", () => {
         )
   );
 
+  test("multiple setState calls", () => {
+    let rootNode = createRootNode();
+
+    let container = createContainer(rootNode);
+
+    let event: Event.t((int, int, int)) = Event.create();
+
+    updateContainer(container, <ComponentThatUpdatesMultipleStates event />);
+    let expectedStructure: tree(primitives) =
+      TreeNode(
+        Root,
+        [
+          TreeNode(B, [TreeLeaf(A(1)), TreeLeaf(A(2)), TreeLeaf(A(3))]),
+        ],
+      );
+    validateStructure(rootNode, expectedStructure);
+
+    Event.dispatch(event, (10, 11, 12));
+
+    let expectedStructure: tree(primitives) =
+      TreeNode(
+        Root,
+        [
+          TreeNode(
+            B,
+            [TreeLeaf(A(10)), TreeLeaf(A(11)), TreeLeaf(A(12))],
+          ),
+        ],
+      );
+    validateStructure(rootNode, expectedStructure);
+
+    updateContainer(container, <ComponentThatUpdatesMultipleStates event />);
+    let expectedStructure: tree(primitives) =
+      TreeNode(
+        Root,
+        [
+          TreeNode(
+            B,
+            [TreeLeaf(A(10)), TreeLeaf(A(11)), TreeLeaf(A(12))],
+          ),
+        ],
+      );
+    validateStructure(rootNode, expectedStructure);
+  });
+
   test("useState updates state with set function", () => {
     let rootNode = createRootNode();
 
@@ -159,51 +204,6 @@ test("useState", () => {
 
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(5))]);
-    validateStructure(rootNode, expectedStructure);
-  });
-
-  test("multiple setState calls", () => {
-    let rootNode = createRootNode();
-
-    let container = createContainer(rootNode);
-
-    let event: Event.t((int, int, int)) = Event.create();
-
-    updateContainer(container, <ComponentThatUpdatesMultipleStates event />);
-    let expectedStructure: tree(primitives) =
-      TreeNode(
-        Root,
-        [
-          TreeNode(B, [TreeLeaf(A(1)), TreeLeaf(A(2)), TreeLeaf(A(3))]),
-        ],
-      );
-    validateStructure(rootNode, expectedStructure);
-
-    Event.dispatch(event, (10, 11, 12));
-
-    let expectedStructure: tree(primitives) =
-      TreeNode(
-        Root,
-        [
-          TreeNode(
-            B,
-            [TreeLeaf(A(10)), TreeLeaf(A(11)), TreeLeaf(A(12))],
-          ),
-        ],
-      );
-    validateStructure(rootNode, expectedStructure);
-
-    updateContainer(container, <ComponentThatUpdatesMultipleStates event />);
-    let expectedStructure: tree(primitives) =
-      TreeNode(
-        Root,
-        [
-          TreeNode(
-            B,
-            [TreeLeaf(A(10)), TreeLeaf(A(11)), TreeLeaf(A(12))],
-          ),
-        ],
-      );
     validateStructure(rootNode, expectedStructure);
   });
 

--- a/test/HooksUseStateTest.re
+++ b/test/HooksUseStateTest.re
@@ -20,7 +20,10 @@ let cComponent = (~children, ()) => primitiveComponent(C, ~children);
 module ComponentWithState = (
   val createComponent((render, ~children, ()) =>
         render(
-          () => useStateExperimental(2, ((s, _setS)) => <aComponent testVal=s />),
+          () =>
+            useStateExperimental(2, ((s, _setS)) =>
+              <aComponent testVal=s />
+            ),
           ~children,
         )
       )
@@ -65,30 +68,33 @@ test("useState", () => {
   module ComponentThatUpdatesMultipleStates = (
     val component((render, ~children, ~event: Event.t((int, int, int)), ()) =>
           render(
-            () => {
-              useStateExperimental(1, ((s1, setS1)) => {
-              useStateExperimental(2, ((s2, setS2)) => {
-              useStateExperimental(3, ((s3, setS3)) => {
-
-              useEffectExperimental(() => {
-                let unsubscribe = Event.subscribe(event, ((v1, v2, v3)) => {
-                  setS1(v1);  
-                  setS2(v2);
-                  setS3(v3);
-                });
-                () => unsubscribe();
-              }, () => {
-                  <bComponent>
-                      <aComponent testVal=s1 />
-                      <aComponent testVal=s2 />
-                      <aComponent testVal=s3 />
-                  </bComponent>
-              });
-
-              })  ;
-              });   
-            });
-            },
+            () =>
+              useStateExperimental(1, ((s1, setS1)) =>
+                useStateExperimental(2, ((s2, setS2)) =>
+                  useStateExperimental(3, ((s3, setS3)) =>
+                    useEffectExperimental(
+                      () => {
+                        let unsubscribe =
+                          Event.subscribe(
+                            event,
+                            ((v1, v2, v3)) => {
+                              setS1(v1);
+                              setS2(v2);
+                              setS3(v3);
+                            },
+                          );
+                        () => unsubscribe();
+                      },
+                      () =>
+                        <bComponent>
+                          <aComponent testVal=s1 />
+                          <aComponent testVal=s2 />
+                          <aComponent testVal=s3 />
+                        </bComponent>,
+                    )
+                  )
+                )
+              ),
             ~children,
           )
         )
@@ -165,18 +171,39 @@ test("useState", () => {
 
     updateContainer(container, <ComponentThatUpdatesMultipleStates event />);
     let expectedStructure: tree(primitives) =
-      TreeNode(Root, [TreeNode(B, [TreeLeaf(A(1)), TreeLeaf(A(2)), TreeLeaf(A(3))])]);
+      TreeNode(
+        Root,
+        [
+          TreeNode(B, [TreeLeaf(A(1)), TreeLeaf(A(2)), TreeLeaf(A(3))]),
+        ],
+      );
     validateStructure(rootNode, expectedStructure);
 
     Event.dispatch(event, (10, 11, 12));
 
     let expectedStructure: tree(primitives) =
-      TreeNode(Root, [TreeNode(B, [TreeLeaf(A(10)), TreeLeaf(A(11)), TreeLeaf(A(12))])]);
+      TreeNode(
+        Root,
+        [
+          TreeNode(
+            B,
+            [TreeLeaf(A(10)), TreeLeaf(A(11)), TreeLeaf(A(12))],
+          ),
+        ],
+      );
     validateStructure(rootNode, expectedStructure);
 
     updateContainer(container, <ComponentThatUpdatesMultipleStates event />);
     let expectedStructure: tree(primitives) =
-      TreeNode(Root, [TreeNode(B, [TreeLeaf(A(10)), TreeLeaf(A(11)), TreeLeaf(A(12))])]);
+      TreeNode(
+        Root,
+        [
+          TreeNode(
+            B,
+            [TreeLeaf(A(10)), TreeLeaf(A(11)), TreeLeaf(A(12))],
+          ),
+        ],
+      );
     validateStructure(rootNode, expectedStructure);
   });
 

--- a/test/HooksUseStateTest.re
+++ b/test/HooksUseStateTest.re
@@ -142,6 +142,7 @@ test("useState", () => {
 
   test("useState set state persists across renders", () => {
     let rootNode = createRootNode();
+
     let container = createContainer(rootNode);
 
     let event: Event.t(int) = Event.create();
@@ -149,18 +150,15 @@ test("useState", () => {
     updateContainer(container, <ComponentThatUpdatesState event />);
 
     Event.dispatch(event, 5);
+
     let expectedStructure: tree(primitives) =
       TreeNode(Root, [TreeLeaf(A(5))]);
     validateStructure(rootNode, expectedStructure);
 
-    Event.dispatch(event, 6);
-    let expectedStructure: tree(primitives) =
-      TreeNode(Root, [TreeLeaf(A(6))]);
-    validateStructure(rootNode, expectedStructure);
+    updateContainer(container, <ComponentThatUpdatesState event />);
 
-    Event.dispatch(event, 7);
     let expectedStructure: tree(primitives) =
-      TreeNode(Root, [TreeLeaf(A(7))]);
+      TreeNode(Root, [TreeLeaf(A(5))]);
     validateStructure(rootNode, expectedStructure);
   });
 


### PR DESCRIPTION
This was a test case discussed with @lpalmes on Discord - wanted to make sure we have coverage for it! I don't believe we had any cases testing multiple subsequent `setState` calls.

It'll be important to make sure we have this working and covered via tests build-over-build, especially if we look at performance improvements (like batching multiple updates/setStates, etc)