### PR TITLE
Move version back to v2.2 and rename continuation hooks to `use*Experimental`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Next release
 
-## 3.0.0
+## 2.2.0
 
-- Continuation-passing style API for hooks: [43](https://github.com/revery-ui/reason-reactify/pull/43/)
+- Experimental continuation-passing style API for hooks: [43](https://github.com/revery-ui/reason-reactify/pull/43/) and [49](https://github.com/revery-ui/reason-reactify/pull/49/)
 
 ## 2.0.0
 

--- a/examples/dom/WebReconciler.re
+++ b/examples/dom/WebReconciler.re
@@ -153,7 +153,7 @@ let reducer = (state, action) =>
   };
 
 let renderCounter = () =>
-  useReducer(reducer, 0, ((count, dispatch)) =>
+  useReducerExperimental(reducer, 0, ((count, dispatch)) =>
     <view>
       <button title="Decrement" onPress={() => dispatch(Decrement)} />
       <text> {"Counter: " ++ str(count)} </text>

--- a/examples/lambda-term/Lambda_term.re
+++ b/examples/lambda-term/Lambda_term.re
@@ -131,7 +131,7 @@ let reducer = (state, action) =>
   };
 
 let renderCounter = () =>
-  useReducer(reducer, 0, ((count, dispatch)) =>
+  useReducerExperimental(reducer, 0, ((count, dispatch)) =>
     <hbox>
       <button text="Decrement" onClick={() => dispatch(Decrement)} />
       <label text={"Counter: " ++ string_of_int(count)} />
@@ -154,8 +154,8 @@ module Clock = (
   val createComponent((render, ~children, ()) =>
         render(
           () =>
-            useState(0., ((time, setTime)) =>
-              useEffect(
+            useStateExperimental(0., ((time, setTime)) =>
+              useEffectExperimental(
                 () => {
                   let evt =
                     Lwt_engine.on_timer(1.0, true, _ => setTime(Unix.time()));

--- a/lib/Reactify_Types.re
+++ b/lib/Reactify_Types.re
@@ -76,13 +76,10 @@ module type React = {
   };
 
   let createComponent:
-    (
-      (
-        (unit => hook('h), ~children: list(emptyHook)) =>
-        emptyHook
-      ) =>
-      'c
-    ) =>
+    (((unit => hook('h), ~children: list(emptyHook)) => emptyHook) => 'c) =>
+    (module Component with type createElement = 'c and type hooks = 'h);
+  let component:
+    (((unit => hook('h), ~children: list(emptyHook)) => emptyHook) => 'c) =>
     (module Component with type createElement = 'c and type hooks = 'h);
 
   /*
@@ -90,19 +87,21 @@ module type React = {
    */
 
   type providerConstructor('t) =
-    (~children: list(emptyHook), ~value: 't, unit) =>
-    emptyHook;
+    (~children: list(emptyHook), ~value: 't, unit) => emptyHook;
   type contextValue('t);
 
   let getProvider: contextValue('t) => providerConstructor('t);
   let createContext: 't => contextValue('t);
-  let useContext:
-    (contextValue('t), 't => hook('a)) =>
-    (hook(('a, context('t))));
+  let useContext: contextValue('t) => 't;
+  let useContextExperimental:
+    (contextValue('t), 't => hook('a)) => hook(('a, context('t)));
 
   let empty: emptyHook;
 
   let useEffect:
+    (~condition: Effects.effectCondition=?, Effects.effectFunction) => unit;
+
+  let useEffectExperimental:
     (
       ~condition: Effects.effectCondition=?,
       Effects.effectFunction,
@@ -110,11 +109,16 @@ module type React = {
     ) =>
     hook(('a, effect));
 
-  let useState:
+  let useState: 'state => ('state, 'state => unit);
+
+  let useStateExperimental:
     ('state, (('state, 'state => unit)) => hook('a)) =>
     hook(('a, state('state)));
 
   let useReducer:
+    (('state, 'action) => 'state, 'state) => ('state, 'action => unit);
+
+  let useReducerExperimental:
     (
       ('state, 'action) => 'state,
       'state,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reason-reactify",
-  "version": "3.0.0",
+  "version": "2.2.0",
   "description": "Reason workflow with Esy",
   "license": "MIT",
   "scripts": {

--- a/test/ContainerTest.re
+++ b/test/ContainerTest.re
@@ -40,11 +40,11 @@ test("Container", () => {
     val createComponent((render, ~children, ~event: Event.t(int), ()) =>
           render(
             () =>
-              useState(
+              useStateExperimental(
                 2,
                 ((s, setS)) => {
                   print_endline("Value: " ++ string_of_int(s));
-                  useEffect(
+                  useEffectExperimental(
                     () => {
                       let unsubscribe = Event.subscribe(event, v => setS(v));
                       () => unsubscribe();

--- a/test/HooksUseContextTest.re
+++ b/test/HooksUseContextTest.re
@@ -27,7 +27,7 @@ test("HooksUseContext", () => {
     module ComponentThatUsesContext = (
       val createComponent((render, ~children, ()) =>
             render(
-              () => useContext(testContext, ctx => <aComponent testVal=ctx />),
+              () => useContextExperimental(testContext, ctx => <aComponent testVal=ctx />),
               ~children,
             )
           )
@@ -51,7 +51,7 @@ test("HooksUseContext", () => {
       val createComponent((render, ~children, ()) =>
             render(
               () =>
-                useContext(testContext, ctx =>
+                useContextExperimental(testContext, ctx =>
                   <provider value=9> <aComponent testVal=ctx /> </provider>
                 ),
               ~children,
@@ -76,7 +76,7 @@ test("HooksUseContext", () => {
     module ComponentThatUsesContext = (
       val createComponent((render, ~children, ()) =>
             render(
-              () => useContext(testContext, ctx => <aComponent testVal=ctx />),
+              () => useContextExperimental(testContext, ctx => <aComponent testVal=ctx />),
               ~children,
             )
           )

--- a/test/HooksUseEffectTest.re
+++ b/test/HooksUseEffectTest.re
@@ -28,7 +28,7 @@ module ComponentWithEffectOnMount = (
         ) =>
         render(
           () =>
-            useEffect(
+            useEffectExperimental(
               () => {
                 functionToCallOnMount();
                 () => functionToCallOnUnmount();
@@ -52,7 +52,7 @@ module ComponentWithEmptyConditionalEffect = (
         render(
           () =>
             /* Hooks */
-            useEffect(
+            useEffectExperimental(
               ~condition=MountUnmount,
               () => {
                 functionToCallOnMount();

--- a/test/HooksUseReducerTest.re
+++ b/test/HooksUseReducerTest.re
@@ -30,7 +30,7 @@ module ComponentWithState = (
   val createComponent((render, ~children, ()) =>
         render(
           () =>
-            useReducer(reducer, 2, ((s, _dispatch)) =>
+            useReducerExperimental(reducer, 2, ((s, _dispatch)) =>
               <aComponent testVal=s />
             ),
           ~children,
@@ -61,8 +61,8 @@ test("useReducer", () => {
           (render, ~children, ~event: Event.t(unit), ~initialValue: int, ()) =>
           render(
             () =>
-              useReducer(reducer, initialValue, ((s, dispatch)) =>
-                useEffect(
+              useReducerExperimental(reducer, initialValue, ((s, dispatch)) =>
+                useEffectExperimental(
                   () => {
                     let unsubscribe =
                       Event.subscribe(event, () => dispatch(Increase));
@@ -182,8 +182,8 @@ test("useReducer", () => {
           (render, ~children, ~event: Event.t(unit), ~initialValue: int, ()) =>
           render(
             () =>
-              useReducer(reducer, initialValue, ((s, dispatch)) =>
-                useEffect(
+              useReducerExperimental(reducer, initialValue, ((s, dispatch)) =>
+                useEffectExperimental(
                   () => {
                     let unsubscribe =
                       Event.subscribe(event, () => dispatch(Increase));

--- a/test/HooksUseStateTest.re
+++ b/test/HooksUseStateTest.re
@@ -20,7 +20,7 @@ let cComponent = (~children, ()) => primitiveComponent(C, ~children);
 module ComponentWithState = (
   val createComponent((render, ~children, ()) =>
         render(
-          () => useState(2, ((s, _setS)) => <aComponent testVal=s />),
+          () => useStateExperimental(2, ((s, _setS)) => <aComponent testVal=s />),
           ~children,
         )
       )
@@ -48,8 +48,8 @@ test("useState", () => {
     val createComponent((render, ~children, ~event: Event.t(int), ()) =>
           render(
             () =>
-              useState(2, ((s, setS)) =>
-                useEffect(
+              useStateExperimental(2, ((s, setS)) =>
+                useEffectExperimental(
                   () => {
                     let unsubscribe = Event.subscribe(event, v => setS(v));
                     () => unsubscribe();
@@ -152,8 +152,8 @@ test("useState", () => {
     val createComponent((render, ~children, ~event: Event.t(int), ()) =>
           render(
             () =>
-              useState(2, ((s, setS)) =>
-                useEffect(
+              useStateExperimental(2, ((s, setS)) =>
+                useEffectExperimental(
                   () => {
                     let unsubscribe = Event.subscribe(event, v => setS(v));
                     () => unsubscribe();
@@ -206,8 +206,8 @@ test("useState", () => {
           render(
             () =>
               /* Hooks */
-              useState(RenderAComponentWithState, ((s, setS)) =>
-                useEffect(
+              useStateExperimental(RenderAComponentWithState, ((s, setS)) =>
+                useEffectExperimental(
                   () => {
                     let unsubscribe = Event.subscribe(event, v => setS(v));
                     () => unsubscribe();


### PR DESCRIPTION
@bryphe As discussed in Discord, this PR:

- adds back the original hook functions (with no `continuation`) 
- renames the continuation hooks to `use*Experimental`
- adds back the `component` creation function (both `component` and `createComponent` are kept)
- changes `package.json` back to 2.2.0 (could be 2.1.0 as before if you prefer)

The idea is that we give ourselves some space to explore the new hooks APIs, considering we have to add the ppx (which involve maybe some adaptation if we use `let-anything`) + the potential API changes that could involve the solution for issue #47.

Let me know what you think! 🙂 