### PR TITLE
Bugfix: Remove unsubscribe 'print_endline' from Event module

### DIFF
--- a/lib/Event.re
+++ b/lib/Event.re
@@ -9,7 +9,6 @@ let create = () => ref([]);
 let subscribe = (evt: t('a), f: cb('a)) => {
   evt := List.append(evt^, [f]);
   let unsubscribe = () => {
-    print_endline("unsubscribe");
     evt := List.filter(f => f !== f, evt^);
   };
   unsubscribe;


### PR DESCRIPTION
Saw a bunch of 'unsubscribe' lines being rendered to the console when testing the change in #174 - this fixes it 👍 